### PR TITLE
Fix/zero weight SRV entries

### DIFF
--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -1018,33 +1018,6 @@ describe("DNS client", function()
       assert.is_nil(ip)
       assert.are.equal("recursion detected", port)
     end)
-    it("passing through the resolver-object", function()
-      assert(client.init())
-
-      local _, err1, r1 = client.toip("google.com", 123, false)
-      local q2, err2, r2 = client.toip("google.nl",  123, false, r1)
-      assert.are.equal(123, err1)
-      assert.are.equal(123, err2)
-      assert.is.table(r1)
-      assert.is.table(r2)
-      assert.equal(r1, r2)
-      
-      -- when fetching from cache
-      q2, err2, r2 = client.toip("google.nl",  123, false, r1)
-      assert.equal(r1, r2)
-      
-      -- when its an IPv4 address
-      q2, err2, r2 = client.toip("1.2.3.4",  123, false, r1)
-      assert.equal(r1, r2)
-      
-      -- when its an IPv6 address
-      q2, err2, r2 = client.toip("::1",  123, false, r1)
-      assert.equal(r1, r2)
-      
-      -- when its a bad IPv6 address (ipv6 == more than 1 colon)
-      q2, err2, r2 = client.toip("::1gdhgasga",  123, false, r1)
-      assert.equal(r1, r2)
-    end)
   end)
 
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -1139,15 +1139,20 @@ local function roundRobinW(rec)
     local weightList -- weights for the entry
     local n = 0
     for i, r in ipairs(rec) do
+      -- when weight == 0 then minimal possibility of hitting it
+      -- should occur. Setting it to 1 will prevent the weight-reduction
+      -- from succeeding, hence a longer RR list is created, with
+      -- lower probability of the 0-one being hit.
+      local weight = (r.weight ~= 0 and r.weight or 1)
       if r.priority == topPriority then
         n = n + 1
         prioList[n] = i
-        weightList[n] = r.weight
+        weightList[n] = weight
       elseif r.priority < topPriority then
         n = 1
         topPriority = r.priority
         prioList = { i }
-        weightList = { r.weight }
+        weightList = { weight }
       end
     end
     md.prioList = prioList


### PR DESCRIPTION
This PR for now fixes the case for the `toip` function. But the ring-balancer should also be adjusted for this case.