### PR TITLE
[0.4.x] fix(balancer) when dns resolution fails for the last host

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ use the `rbusted` script.
 History
 =======
 
+### Unreleased
+
+- Fix: failure of the last hostname to resolve (balancer)
+
 ### 0.4.3 (17-Aug-2017) Bugfix
 
 - Fix: return proper hostname for named SRV entries in the balancer

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -538,10 +538,11 @@ function objHost:getPeer(hashValue, cacheOnly, slot)
     -- ttl expired, so must renew
     self:queryDns(cacheOnly)
 
-    if slot.address.host ~= self then
-      -- our slot has been reallocated to another host, so recurse to start over
+    if (not slot.address) or slot.address.host ~= self then
+      -- our slot has been reallocated to another host (or there are no addresses),
+      -- so recurse to start over (or to give a proper error message)
       ngx_log(ngx_DEBUG, log_prefix, "slot previously assigned to ", self.hostname,
-              " was reassigned to another due to a dns update")
+              " was reassigned due to a DNS update")
       return self.balancer:getPeer(hashValue, cacheOnly)
     end
   end


### PR DESCRIPTION
Addresses #26 in branch 0.4.x, including a backport of test from PR #27.