### PR TITLE
fix(client) do not fail initialization without nameservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ History
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
+### x.x.x (xx-Dec-2017) Fix
+
+- Fix: do not fail initialization without nameservers. 
+
 ### 1.0.0 (14-Dec-2017) Fixes and IPv6
 
 - Change: BREAKING all IPv6 addresses are now returned with square brackets

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -41,7 +41,10 @@ describe("DNS client", function()
     -- using the `query_func` upvalue defined above
     local old_new = resolver.new
     resolver.new = function(...)
-      local r = old_new(...)
+      local r, err = old_new(...)
+      if not r then
+        return nil, err
+      end
       local original_query_func = r.query
       r.query = function(self, ...)
         return query_func(self, original_query_func, ...)
@@ -62,12 +65,11 @@ describe("DNS client", function()
 
   describe("initialization", function()
 
-    it("fails with no nameservers", function()
+    it("does not fail with no nameservers", function()
       -- empty list fallsback on resolv.conf
       assert.has.no.error(function() client.init( {nameservers = {} } ) end)
 
-      assert.has.error(function() client.init( {nameservers = {}, resolvConf = {} } ) end,
-        "Invalid configuration, no valid nameservers found")    
+      assert.has.no.error(function() client.init( {nameservers = {}, resolvConf = {} } ) end)    
     end)
 
     it("fails with order being empty", function()
@@ -321,6 +323,17 @@ describe("DNS client", function()
 
   end)
 
+
+  it("fetching a record without nameservers errors", function()
+    assert(client.init({ resolvConf = {} }))
+
+    local host = "thijsschreijer.nl"
+    local typ = client.TYPE_A
+
+    local answers, err, try_list = client.resolve(host, { qtype = typ })
+    assert.is_nil(answers)
+    assert(err:find("failed to create a resolver: no nameservers specified"))
+  end)
 
   it("fetching a TXT record", function()
     assert(client.init())

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -454,9 +454,13 @@ _M.init = function(options)
       end
     end
   end
-  assert(#(options.nameservers or {}) > 0, "Invalid configuration, no valid nameservers found")
-  for _, r in ipairs(options.nameservers) do
-    log(log_DEBUG, "nameserver ", type(r) == "table" and (r[1]..":"..r[2]) or r)
+  options.nameservers = options.nameservers or {}
+  if #options.nameservers == 0 then
+    log(log_WARN, "Invalid configuration, no valid nameservers found")
+  else
+    for _, r in ipairs(options.nameservers) do
+      log(log_DEBUG, "nameserver ", type(r) == "table" and (r[1]..":"..r[2]) or r)
+    end
   end
   
   options.retrans = options.retrans or resolv.options.attempts or 5 -- 5 is openresty default


### PR DESCRIPTION
In a scenario with all lookups being ip based, the lack of nameservers should not fail.

fixes https://github.com/Kong/kong/issues/3104