### PR TITLE
Reducing the memory footprint of large balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ History
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
-### x.x.x (xx-Dec-2017) Fix
+### 2.0.0 (xx-Jan-2018) Major performance improvement (balancer)
 
+- BREAKING: improved performance and memory footprint for large balancers.
+  80-85% less memory will be used, while creation time dropped by 85-90%. Since
+  the `host:getPeer()` function signature changed, this is a breaking change.
 - Fix: do not fail initialization without nameservers. 
 
 ### 1.0.0 (14-Dec-2017) Fixes and IPv6

--- a/spec/balancer_spec.lua
+++ b/spec/balancer_spec.lua
@@ -125,34 +125,11 @@ local check_list = function(t)
   return size, keys
 end
 
--- returns number of entries (hash + array part)
-local table_size = function(t)
-  local s = 0
-  for _, _ in pairs(t) do s = s + 1 end
-  return s
-end
-
 -- checks the integrity of the balancer, hosts, addresses, and slots. returns the balancer.
 local check_balancer = function(balancer)
   assert.is.table(balancer)
-  -- hosts
   check_list(balancer.hosts)
-  -- slots
-  local size = check_list(balancer.slots)
-  assert.are.equal(balancer.wheelSize, size)
-  assert.are.equal(check_list(balancer.wheel), size)
-  local templist = {}
-  for i, slot in ipairs(balancer.slots) do
-    local idx = slot.order
-    assert.are.equal(balancer.wheel[idx], slot)
-    templist[slot] = i
-  end
-  assert.are.equal(balancer.wheelSize, table_size(templist))
-  for i, slot in ipairs(balancer.wheel) do
-    assert.are.equal(slot.order, i)
-    templist[slot] = nil
-  end
-  assert.are.equal(0, table_size(templist))
+  assert.are.equal(check_list(balancer.wheel), balancer.wheelSize)
   if balancer.weight == 0 then
     -- all hosts failed, so the balancer slots have no content
     assert.are.equal(balancer.wheelSize, #balancer.unassignedSlots)
@@ -552,7 +529,7 @@ describe("Loadbalancer", function()
         local ok, err = b:setPeerStatus(false, "1.2.3.4", 80, "1.2.3.4")
         assert.is_true(ok)
         assert.is_nil(err)
-        local ok, err = b:setPeerStatus(false, "4.3.2.1", 80, "kong.inc")
+        ok, err = b:setPeerStatus(false, "4.3.2.1", 80, "kong.inc")
         assert.is_true(ok)
         assert.is_nil(err)
       end)
@@ -566,7 +543,7 @@ describe("Loadbalancer", function()
         local ok, err = b:setPeerStatus(false, "1.1.1.1", 80)
         assert.is_nil(ok)
         assert.equals("no peer found by name '1.1.1.1' and address 1.1.1.1:80", err)
-        local ok, err = b:setPeerStatus(false, "1.1.1.1", 80, "kong.inc")
+        ok, err = b:setPeerStatus(false, "1.1.1.1", 80, "kong.inc")
         assert.is_nil(ok)
         assert.equals("no peer found by name 'kong.inc' and address 1.1.1.1:80", err)
       end)

--- a/spec/balancer_spec.lua
+++ b/spec/balancer_spec.lua
@@ -125,30 +125,30 @@ local check_list = function(t)
   return size, keys
 end
 
--- checks the integrity of the balancer, hosts, addresses, and slots. returns the balancer.
+-- checks the integrity of the balancer, hosts, addresses, and indices. returns the balancer.
 local check_balancer = function(balancer)
   assert.is.table(balancer)
   check_list(balancer.hosts)
   assert.are.equal(balancer.wheelSize, check_list(balancer.wheel)+check_list(balancer.unassignedWheelIndices))
   if balancer.weight == 0 then
-    -- all hosts failed, so the balancer slots have no content
+    -- all hosts failed, so the balancer indices are unassigned/empty
     assert.are.equal(balancer.wheelSize, #balancer.unassignedWheelIndices)
-    for _, slot in ipairs(balancer.wheel) do
-      assert.is_nil(slot.address)
+    for _, address in ipairs(balancer.wheel) do
+      assert.is_nil(address)
     end
   else
     -- addresses
     local addrlist = {}
-    for _, address in ipairs(balancer.wheel) do -- calculate slots per address based on the wheel
+    for _, address in ipairs(balancer.wheel) do -- calculate indices per address based on the wheel
       addrlist[address] = (addrlist[address] or 0) + 1
     end
     for addr, count in pairs(addrlist) do
-      assert.are.equal(#addr.slots, count)
+      assert.are.equal(#addr.indices, count)
     end
-    for _, host in ipairs(balancer.hosts) do -- remove slots per address based on hosts (results in 0)
+    for _, host in ipairs(balancer.hosts) do -- remove indices per address based on hosts (results in 0)
       for _, addr in ipairs(host.addresses) do
         if addr.weight > 0 then
-          for _ in ipairs(addr.slots) do
+          for _ in ipairs(addr.indices) do
             addrlist[addr] = addrlist[addr] - 1
           end
         end
@@ -161,8 +161,8 @@ local check_balancer = function(balancer)
   return balancer
 end
 
--- creates a hash table with "address:port" keys and as value the number of slots
-local function count_slots(balancer)
+-- creates a hash table with "address:port" keys and as value the number of indices
+local function count_indices(balancer)
   local r = {}
   for _, address in ipairs(balancer.wheel) do
     local key = tostring(address.ip)
@@ -710,7 +710,7 @@ describe("Loadbalancer", function()
         dns = client,
         wheelSize = 15,
       })
-      -- run down the wheel, hitting all slots once
+      -- run down the wheel, hitting all indices once
       local res = {}
       for n = 1, 15 do
         local addr, port, host = b:getPeer(n)
@@ -719,7 +719,7 @@ describe("Loadbalancer", function()
       end
       assert.equal(10, res["1.2.3.4:123"])
       assert.equal(5, res["5.6.7.8:321"])
-      -- hit one slot 15 times
+      -- hit one index 15 times
       res = {}
       local hash = 6  -- just pick one
       for _ = 1, 15 do
@@ -749,7 +749,7 @@ describe("Loadbalancer", function()
         dns = client,
         wheelSize = 10,
       })
-      -- run down the wheel, hitting all slots once
+      -- run down the wheel, hitting all indices once
       for n = 0, 9 do
         local addr1, port1, host1 = b:getPeer(n)
         local addr2, port2, host2 = b:getPeer(n+10) -- wraps around, modulo
@@ -775,7 +775,7 @@ describe("Loadbalancer", function()
         dns = client,
         wheelSize = 10,
       })
-      -- run down the wheel, slot 0, increasing retry
+      -- run down the wheel, index 0, increasing the retry counter
       local res = {}
       for n = 0, 9 do
         local addr, port, _ = b:getPeer(0, n)
@@ -987,8 +987,8 @@ describe("Loadbalancer", function()
     end)
   end)
 
-  describe("slot manipulation", function()
-    it("equal weights and 'fitting' slots", function()
+  describe("wheel manipulation", function()
+    it("equal weights and 'fitting' indices", function()
       dnsA({ 
         { name = "mashape.com", address = "1.2.3.4" },
         { name = "mashape.com", address = "1.2.3.5" },
@@ -1002,9 +1002,9 @@ describe("Loadbalancer", function()
         ["1.2.3.4:80"] = 5,
         ["1.2.3.5:80"] = 5,
       }
-      assert.are.same(expected, count_slots(b))
+      assert.are.same(expected, count_indices(b))
     end)
-    it("equal weights and 'non-fitting' slots", function()
+    it("equal weights and 'non-fitting' indices", function()
       dnsA({ 
         { name = "mashape.com", address = "1.2.3.1" },
         { name = "mashape.com", address = "1.2.3.2" },
@@ -1034,7 +1034,7 @@ describe("Loadbalancer", function()
         ["1.2.3.9:80"] = 2,
         ["1.2.3.10:80"] = 2, 
       }
-      assert.are.same(expected, count_slots(b))
+      assert.are.same(expected, count_indices(b))
     end)
     it("DNS record order has no effect", function()
       dnsA({ 
@@ -1054,7 +1054,7 @@ describe("Loadbalancer", function()
         dns = client,
         wheelSize = 19,
       })
-      local expected = count_slots(b)
+      local expected = count_indices(b)
       dnsA({ 
         { name = "mashape.com", address = "1.2.3.8" },
         { name = "mashape.com", address = "1.2.3.3" },
@@ -1073,7 +1073,7 @@ describe("Loadbalancer", function()
         wheelSize = 19,
       })
       
-      assert.are.same(expected, count_slots(b))
+      assert.are.same(expected, count_indices(b))
     end)
     it("changing hostname order has no effect", function()
       dnsA({ 
@@ -1087,15 +1087,15 @@ describe("Loadbalancer", function()
         dns = client,
         wheelSize = 3,
       }
-      local expected = count_slots(b)
+      local expected = count_indices(b)
       b = check_balancer(balancer.new { 
         hosts = {"getkong.org", "mashape.com"},  -- changed host order
         dns = client,
         wheelSize = 3,
       })
-      assert.are.same(expected, count_slots(b))
+      assert.are.same(expected, count_indices(b))
     end)
-    it("adding a host (non-fitting slots)", function()
+    it("adding a host (non-fitting indices)", function()
       dnsA({ 
         { name = "mashape.com", address = "1.2.3.4" },
         { name = "mashape.com", address = "1.2.3.5" },
@@ -1115,9 +1115,9 @@ describe("Loadbalancer", function()
         ["1.2.3.5:80"] = 2,
         ["[::1]:8080"] = 6,
       }
-      assert.are.same(expected, count_slots(b))
+      assert.are.same(expected, count_indices(b))
     end)
-    it("adding a host (fitting slots)", function()
+    it("adding a host (fitting indices)", function()
       dnsA({ 
         { name = "mashape.com", address = "1.2.3.4" },
         { name = "mashape.com", address = "1.2.3.5" },
@@ -1137,9 +1137,9 @@ describe("Loadbalancer", function()
         ["1.2.3.5:80"] = 500,
         ["[::1]:8080"] = 1000,
       }
-      assert.are.same(expected, count_slots(b))
+      assert.are.same(expected, count_indices(b))
     end)
-    it("removing a host, slots staying in place", function()
+    it("removing a host, indices staying in place", function()
       dnsA({ 
         { name = "mashape.com", address = "1.2.3.4" },
         { name = "mashape.com", address = "1.2.3.5" },
@@ -1155,22 +1155,22 @@ describe("Loadbalancer", function()
       b:addHost("getkong.org", 8080, 10)
       check_balancer(b)
       
-      -- copy the first 500 slots, they should not move
+      -- copy the first 500 indices, they should not move
       local expected1 = {}
-      icopy(expected1, b.hosts[1].addresses[1].slots, 1, 1, 500)
+      icopy(expected1, b.hosts[1].addresses[1].indices, 1, 1, 500)
       local expected2 = {}
-      icopy(expected2, b.hosts[1].addresses[2].slots, 1, 1, 500)
+      icopy(expected2, b.hosts[1].addresses[2].indices, 1, 1, 500)
       
       b:removeHost("getkong.org")
       check_balancer(b)
       
-      -- copy the new first 500 slots as well
+      -- copy the new first 500 indices as well
       local expected1a = {}
-      icopy(expected1a, b.hosts[1].addresses[1].slots, 1, 1, 500)
+      icopy(expected1a, b.hosts[1].addresses[1].indices, 1, 1, 500)
       local expected2a = {}
-      icopy(expected2a, b.hosts[1].addresses[2].slots, 1, 1, 500)
+      icopy(expected2a, b.hosts[1].addresses[2].indices, 1, 1, 500)
 
-      -- compare previous copy against current first 500 slots to make sure they are the same
+      -- compare previous copy against current first 500 indices to make sure they are the same
       for i = 1,500 do
         assert(expected1[i] == expected1a[i])
         assert(expected1[i] == expected1a[i])
@@ -1207,7 +1207,7 @@ describe("Loadbalancer", function()
       })
       b:addHost("mashape.com", 80, 10)
       b:addHost("getkong.org", 80, 10)
-      local count = count_slots(b)
+      local count = count_indices(b)
       assert.same({
           ["1.2.3.4:80"] = 20,
           ["1.2.3.5:80"] = 20,
@@ -1215,7 +1215,7 @@ describe("Loadbalancer", function()
       }, count)
       
       b:addHost("mashape.com", 80, 25)
-      count = count_slots(b)
+      count = count_indices(b)
       assert.same({
           ["1.2.3.4:80"] = 25,
           ["1.2.3.5:80"] = 25,
@@ -1263,7 +1263,7 @@ describe("Loadbalancer", function()
         ttl0 = 2,
       })
     
-      local count = count_slots(b)
+      local count = count_indices(b)
       assert.same({
           ["mashape.com:80"] = 50,
           ["9.9.9.9:123"] = 50,
@@ -1272,7 +1272,7 @@ describe("Loadbalancer", function()
       -- update weights
       b:addHost("mashape.com", 80, 150)
       
-      count = count_slots(b)
+      count = count_indices(b)
       assert.same({
           ["mashape.com:80"] = 75,
           ["9.9.9.9:123"] = 25,
@@ -1291,7 +1291,7 @@ describe("Loadbalancer", function()
       })
       b:addHost("does.not.exist.mashape.com", 80, 10)
       b:addHost("getkong.org", 80, 10)
-      local count = count_slots(b)
+      local count = count_indices(b)
       assert.same({
           ["1.2.3.4:80"] = 30,
           ["[::1]:80"]   = 30,
@@ -1306,7 +1306,7 @@ describe("Loadbalancer", function()
       
       for _ = 1, b.wheelSize do b:getPeer() end -- hit them all to force renewal
       
-      count = count_slots(b)
+      count = count_indices(b)
       assert.same({
           --["1.2.3.4:80"] = 0,  --> failed to resolve, no more entries
           ["[::1]:80"]   = 60,
@@ -1320,7 +1320,7 @@ describe("Loadbalancer", function()
       })
       sleep(2)  -- wait for timer to re-resolve the record
       
-      count = count_slots(b)
+      count = count_indices(b)
       assert.same({
           ["1.2.3.4:80"] = 40,
           ["[::1]:80"]   = 20,
@@ -1341,7 +1341,7 @@ describe("Loadbalancer", function()
       })
       b:addHost("mashape.com", 80, 10)
       b:addHost("gelato.io", 80, 10)  --> port + weight will be ignored
-      local count = count_slots(b)
+      local count = count_indices(b)
       local state = copyWheel(b)
       assert.same({
           ["1.2.3.4:80"]   = 40,
@@ -1351,7 +1351,7 @@ describe("Loadbalancer", function()
       }, count)
       
       b:addHost("gelato.io", 80, 20)  --> port + weight will be ignored
-      count = count_slots(b)
+      count = count_indices(b)
       assert.same({
           ["1.2.3.4:80"]   = 40,
           ["1.2.3.5:80"]   = 40,
@@ -1481,10 +1481,10 @@ describe("Loadbalancer", function()
         b:getPeer()  -- invoke balancer, to expire record and re-query dns
       end
       assert.spy(client.resolve).was_called_with("mashape.com",nil, nil)
-      -- update 'state' to match the changes, slots should remain the same
+      -- update 'state' to match the changes, indices should remain the same
       -- only the content has changed.
       -- Note: when the record changes, all addresses are deleted, in reverse
-      -- order. So the slots from '::2' are freed first, followed by '::1'.
+      -- order. So the indices from '::2' are freed first, followed by '::1'.
       -- So when 1.2.3.5 is added, it gets the ones last freed from '::1'
       -- So order is DETERMINISTIC!
       updateWheelState(state, " %- ::1 @ ", " - 1.2.3.5 @ ")
@@ -1519,7 +1519,7 @@ describe("Loadbalancer", function()
         b:getPeer()  -- invoke balancer, to expire record and re-query dns
       end
       assert.spy(client.resolve).was_called_with("mashape.com",nil, nil)
-      -- update 'state' to match the changes, slots should remain the same
+      -- update 'state' to match the changes, indices should remain the same
       -- only the content has changed.
       -- Note: when the record changes, the addresses are deleted in order
       -- so 1.2.3.4 goes first, followed by 1.2.3.5. Adding is also in order
@@ -1557,7 +1557,7 @@ describe("Loadbalancer", function()
         b:getPeer()  -- invoke balancer, to expire record and re-query dns
       end
       assert.spy(client.resolve).was_called_with("mashape.com",nil, nil)
-      -- update 'state' to match the changes, slots should remain the same
+      -- update 'state' to match the changes, indices should remain the same
       -- only the content has changed.
       --
       -- Note: order was changed, 1.2.3.5 moved from 2nd to 1st position
@@ -1593,7 +1593,7 @@ describe("Loadbalancer", function()
       -- run entire wheel to make sure the expired one is requested, and updated
       for _ = 1, b.wheelSize do b:getPeer() end 
       -- all old 'mashape.com @ 1.2.3.5' should now be 'mashape.com @ 1.2.3.6'
-      -- and more important; all others should not have moved slot positions!
+      -- and more important; all others should not have moved indices/positions!
       updateWheelState(state, " %- 1%.2%.3%.5 @ ", " - 1.2.3.6 @ ")
       assert.same(state, copyWheel(b))
     end)
@@ -1630,7 +1630,7 @@ describe("Loadbalancer", function()
       record.expire = gettime() -1 -- expire current dns cache record
       -- run entire wheel to make sure the expired one is requested, so it can fail
       for _ = 1, b.wheelSize do b:getPeer() end
-      -- all slots are now getkong.org
+      -- all indices are now getkong.org
       updateWheelState(state2, " %- 1%.2%.3%.4 @ 80 %(mashape%.com%)", " - 9.9.9.9 @ 123 (getkong.org)")
       
       assert.same(state2, copyWheel(b))
@@ -1741,8 +1741,8 @@ describe("Loadbalancer", function()
       assert.same(res, res2)
 
     end)
-    it("low weight with zero-slots assigned doesn't fail", function()
-      -- depending on order of insertion it is either 1 or 0 slots
+    it("low weight with zero-indices assigned doesn't fail", function()
+      -- depending on order of insertion it is either 1 or 0 indices
       -- but it may never error.
       local record = dnsA({ 
         { name = "mashape.com", address = "1.2.3.4" },
@@ -1775,7 +1775,7 @@ describe("Loadbalancer", function()
       })
     end)
     it("SRV record with 0 weight doesn't fail resolving", function()
-      -- depending on order of insertion it is either 1 or 0 slots
+      -- depending on order of insertion it is either 1 or 0 indices
       -- but it may never error.
       dnsSRV({
         { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 0 },
@@ -1843,7 +1843,7 @@ describe("Loadbalancer", function()
       local state = copyWheel(b)
       -- run it down, count the dns queries done
       for _ = 1, b.wheelSize do b:getPeer() end 
-      assert.equal(b.wheelSize/2, toip_count)  -- one resolver hit for each slot entry
+      assert.equal(b.wheelSize/2, toip_count)  -- one resolver hit for each index
       assert.equal(1, resolve_count) -- hit once, when adding the host to the balancer
       
       -- wait for expiring the 0-ttl setting
@@ -1857,7 +1857,7 @@ describe("Loadbalancer", function()
       assert.equal(0, toip_count)
       assert.equal(1, resolve_count) -- hit once, when updating the 0-ttl entry
       
-      -- finally check whether slots didn't move around
+      -- finally check whether indices didn't move around
       updateWheelState(state, " %- mashape%.com @ ", " - 1.2.3.4 @ ")
       assert.same(state, copyWheel(b))
     end)

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -1081,7 +1081,6 @@ _M.new = function(opts)
     hosts = {},    -- a table, index by both the hostname and index, the value being a host object
     weight = 0,    -- total weight of all hosts
     wheel = nil,   -- wheel with entries (fully randomized)
-    slots = nil,   -- list of slots in no particular order
     pointer = 1,   -- pointer to next-up slot for the round robin scheme
     wheelSize = opts.wheelSize or 1000, -- number of entries in the wheel
     dns = opts.dns,  -- the configured dns client to use for resolving
@@ -1093,17 +1092,13 @@ _M.new = function(opts)
   }
   for name, method in pairs(objBalancer) do self[name] = method end
   self.wheel = new_tab(self.wheelSize, 0)
-  self.slots = new_tab(self.wheelSize, 0)
   self.unassignedSlots = new_tab(self.wheelSize, 0)
 
   -- Create a list of entries, and randomize them.
-  -- 'slots' is just for tracking the individual entries, no notion of order is necessary
-  -- 'wheel' is fully randomized, no matter how 'slots' is modified, 'wheel' remains random.
   -- Create the wheel
   local wheel = self.wheel
-  local slots = self.slots
   local slotList = self.unassignedSlots
-  local duplicateCheck = {}
+  local duplicateCheck = new_tab(self.wheelSize, 0)
   local orderlist = opts.order or randomlist(self.wheelSize)
 
   for i = 1, self.wheelSize do
@@ -1117,8 +1112,7 @@ _M.new = function(opts)
     slot.order = order           -- the order in the slot wheel
     slot.address = nil           -- the address this slot belongs to (set by `addSlots` and `dropSlots` methods)
     
-    slots[i] = slot
-    wheel[order] = slot
+    wheel[order] = slot  -- slots randomly ordered on wheel!
     slotList[i] = slot
   end
   

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -770,7 +770,10 @@ function objBalancer:addHost(hostname, port, weight)
       end
     end
   end
-  
+
+  if #self.unassignedSlots == 0 then
+    self.unassignedSlots = {}  -- replace table because of initial memory footprint
+  end
   return self
 end
 
@@ -804,6 +807,9 @@ function objBalancer:removeHost(hostname, port)
       table_remove(self.hosts, i)
       break
     end
+  end
+  if #self.unassignedSlots == 0 then
+    self.unassignedSlots = {}  -- replace table because of initial memory footprint
   end
   return self
 end


### PR DESCRIPTION
In addition to #32 this adds more improvements, mostly on memory consumption.

Test case with a very large balancer having 100 targets and a size of 65535:

**Release 1.0**:

- Memory: 10.5 mb
- creation time: 95/100ms


**After #32 & #33**

- Memory: 1.7mb
- creation time: 10ms

Unfortunately it is a breaking change since the `host:getPeer()` method changed signature.
