### PR TITLE
fix(hosts) ensure hostsfile ipv6 are also normalized with brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
 ### x.x.x (xx-Dec-2017) Fix
 
-- Fix: do not fail initialization without nameservers. 
+- Fix: do not fail initialization without nameservers.
+- Fix: properly recognize IPv6 in square brackets from the /etc/hosts file.
 
 ### 1.0.0 (14-Dec-2017) Fixes and IPv6
 

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -812,9 +812,6 @@ describe("DNS client", function()
 
 123.123.123.123 mashape
 1234::1234 kong.for.president
-
-123.123.123.123:80 namewithport1  #inserted as SRV
-[1234::1234]:81 namewithport2     #inserted as SRV
 ]])
 
     assert(client.init({ hosts = f }))
@@ -835,21 +832,6 @@ describe("DNS client", function()
     answers, err = client.resolve("kong.for.president", {qtype = client.TYPE_AAAA})
     assert.is.Nil(err)
     assert.are.equal(answers[1].address, "[1234::1234]")
-
-    answers, err = client.resolve("namewithport1", {qtype = client.TYPE_SRV})
-    assert.is.Nil(err)
-    assert.are.equal(answers[1].target, "123.123.123.123")
-    assert.are.equal(answers[1].port, 80)
-    assert.are.equal(answers[1].weight, 10)
-    assert.are.equal(answers[1].priority, 20)
-
-    answers, err = client.resolve("namewithport2", {qtype = client.TYPE_SRV})
-    assert.is.Nil(err)
-    assert.are.equal(answers[1].target, "[1234::1234]")
-    assert.are.equal(answers[1].port, 81)
-    assert.are.equal(answers[1].weight, 10)
-    assert.are.equal(answers[1].priority, 20)
-
   end)
 
   describe("toip() function", function()

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -812,6 +812,9 @@ describe("DNS client", function()
 
 123.123.123.123 mashape
 1234::1234 kong.for.president
+
+123.123.123.123:80 namewithport1  #inserted as SRV
+[1234::1234]:81 namewithport2     #inserted as SRV
 ]])
 
     assert(client.init({ hosts = f }))
@@ -832,6 +835,21 @@ describe("DNS client", function()
     answers, err = client.resolve("kong.for.president", {qtype = client.TYPE_AAAA})
     assert.is.Nil(err)
     assert.are.equal(answers[1].address, "[1234::1234]")
+
+    answers, err = client.resolve("namewithport1", {qtype = client.TYPE_SRV})
+    assert.is.Nil(err)
+    assert.are.equal(answers[1].target, "123.123.123.123")
+    assert.are.equal(answers[1].port, 80)
+    assert.are.equal(answers[1].weight, 10)
+    assert.are.equal(answers[1].priority, 20)
+
+    answers, err = client.resolve("namewithport2", {qtype = client.TYPE_SRV})
+    assert.is.Nil(err)
+    assert.are.equal(answers[1].target, "[1234::1234]")
+    assert.are.equal(answers[1].port, 81)
+    assert.are.equal(answers[1].weight, 10)
+    assert.are.equal(answers[1].priority, 20)
+
   end)
 
   describe("toip() function", function()

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -51,8 +51,6 @@ describe("testing parsing 'hosts'", function()
 127.0.0.3  www.abcsearch.com wwwsearch #[Restricted Zone site]
 
 [::1]        alsolocalhost  #support IPv6 in brackets
-[::1]:80     localport6     #allow port number
-127.0.0.1:80 localport4     #allow port number
 ]])
     local reverse, hosts = dnsutils.parseHosts(hostsfile)
     assert.is.equal(hosts[1].ip, "127.0.0.1")
@@ -98,21 +96,6 @@ describe("testing parsing 'hosts'", function()
     assert.is.equal(hosts[10].canonical, "alsolocalhost")
     assert.is.equal(hosts[10].family, "ipv6")
     assert.is.equal("[::1]", reverse["alsolocalhost"].ipv6)
-
-    assert.is.equal(hosts[11].ip, "[::1]")
-    assert.is.equal(hosts[11].port, 80)
-    assert.is.equal(hosts[11].canonical, "localport6")
-    assert.is.equal(hosts[11].family, "ipv6")
-    assert.is.equal("[::1]", reverse["localport6"].ipv6)
-    assert.is.equal(80, reverse["localport6"].ipv6_port)
-
-    assert.is.equal(hosts[12].ip, "127.0.0.1")
-    assert.is.equal(hosts[12].port, 80)
-    assert.is.equal(hosts[12].canonical, "localport4")
-    assert.is.equal(hosts[12].family, "ipv4")
-    assert.is.equal("127.0.0.1", reverse["localport4"].ipv4)
-    assert.is.equal(80, reverse["localport4"].ipv4_port)
-
   end)
 
 end)

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -49,6 +49,10 @@ describe("testing parsing 'hosts'", function()
 127.0.0.1  admin.abcsearch.com
 127.0.0.2  www3.abcsearch.com #[Browseraid]
 127.0.0.3  www.abcsearch.com wwwsearch #[Restricted Zone site]
+
+[::1]        alsolocalhost  #support IPv6 in brackets
+[::1]:80     localport6     #allow port number
+127.0.0.1:80 localport4     #allow port number
 ]])
     local reverse, hosts = dnsutils.parseHosts(hostsfile)
     assert.is.equal(hosts[1].ip, "127.0.0.1")
@@ -56,9 +60,9 @@ describe("testing parsing 'hosts'", function()
     assert.is.Nil(hosts[1][1])  -- no aliases
     assert.is.Nil(hosts[1][2])
     assert.is.equal("127.0.0.1", reverse.localhost.ipv4)
-    assert.is.equal("::1", reverse.localhost.ipv6)
+    assert.is.equal("[::1]", reverse.localhost.ipv6)
   
-    assert.is.equal(hosts[2].ip, "::1")
+    assert.is.equal(hosts[2].ip, "[::1]")
     assert.is.equal(hosts[2].canonical, "localhost")
     
     assert.is.equal(hosts[3].ip, "192.168.1.2")
@@ -89,6 +93,26 @@ describe("testing parsing 'hosts'", function()
     assert.is.Nil(hosts[6][2])
     assert.is.equal("192.168.1.4", reverse["smtp.computer.com"].ipv4)  -- .1.4; first one wins!
     assert.is.equal("192.168.1.4", reverse["alias3"].ipv4)   -- .1.4; first one wins!
+
+    assert.is.equal(hosts[10].ip, "[::1]")
+    assert.is.equal(hosts[10].canonical, "alsolocalhost")
+    assert.is.equal(hosts[10].family, "ipv6")
+    assert.is.equal("[::1]", reverse["alsolocalhost"].ipv6)
+
+    assert.is.equal(hosts[11].ip, "[::1]")
+    assert.is.equal(hosts[11].port, 80)
+    assert.is.equal(hosts[11].canonical, "localport6")
+    assert.is.equal(hosts[11].family, "ipv6")
+    assert.is.equal("[::1]", reverse["localport6"].ipv6)
+    assert.is.equal(80, reverse["localport6"].ipv6_port)
+
+    assert.is.equal(hosts[12].ip, "127.0.0.1")
+    assert.is.equal(hosts[12].port, 80)
+    assert.is.equal(hosts[12].canonical, "localport4")
+    assert.is.equal(hosts[12].family, "ipv4")
+    assert.is.equal("127.0.0.1", reverse["localport4"].ipv4)
+    assert.is.equal(80, reverse["localport4"].ipv4_port)
+
   end)
 
 end)

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -391,53 +391,34 @@ _M.init = function(options)
   local ttl = 10*365*24*60*60  -- use ttl of 10 years for hostfile entries
   for name, address in pairs(hosts) do
     name = string_lower(name)
-    if address.ipv4_port or address.ipv6_port then
-      -- entry with a port number, create SRV
+    if address.ipv4 then 
       cacheinsert({{  -- NOTE: nested list! cache is a list of lists
           name = name,
-          target = address.ipv4 or address.ipv6,
-          port = address.ipv4_port or address.ipv6_port,
-          type = _M.TYPE_SRV,
+          address = address.ipv4,
+          type = _M.TYPE_A,
           class = 1,
           ttl = ttl,
-          priority = 20,  -- arbitrary...
-          weight = 10,    -- arbitrary...
         }})
-      defined_hosts[name..":".._M.TYPE_SRV] = true
-      cachesetsuccess(name, _M.TYPE_SRV)
-      log(log_DEBUG, "adding SRV-record from 'hosts' file: ",name, " = ",
-        address.ipv6 or address.ipv4, ":", address.ipv6_port or address.ipv4_port)
-    else
-      -- entry without a port number, create A or AAAA
-      if address.ipv4 then
-        cacheinsert({{  -- NOTE: nested list! cache is a list of lists
-            name = name,
-            address = address.ipv4,
-            type = _M.TYPE_A,
-            class = 1,
-            ttl = ttl,
-          }})
-        defined_hosts[name..":".._M.TYPE_A] = true
-        -- cache is empty so far, so no need to check for the ip_preference
-        -- field here, just set ipv4 as success-type.
-        cachesetsuccess(name, _M.TYPE_A)
-        log(log_DEBUG, "adding A-record from 'hosts' file: ",name, " = ", address.ipv4)
+      defined_hosts[name..":".._M.TYPE_A] = true
+      -- cache is empty so far, so no need to check for the ip_preference
+      -- field here, just set ipv4 as success-type.
+      cachesetsuccess(name, _M.TYPE_A)
+      log(log_DEBUG, "adding A-record from 'hosts' file: ",name, " = ", address.ipv4)
+    end
+    if address.ipv6 then 
+      cacheinsert({{  -- NOTE: nested list! cache is a list of lists
+          name = name,
+          address = address.ipv6,
+          type = _M.TYPE_AAAA,
+          class = 1,
+          ttl = ttl,
+        }})
+      defined_hosts[name..":".._M.TYPE_AAAA] = true
+      -- do not overwrite the A success-type unless AAAA is preferred
+      if ip_preference == "AAAA" or not cachegetsuccess(name) then
+        cachesetsuccess(name, _M.TYPE_AAAA)
       end
-      if address.ipv6 then
-        cacheinsert({{  -- NOTE: nested list! cache is a list of lists
-            name = name,
-            address = address.ipv6,
-            type = _M.TYPE_AAAA,
-            class = 1,
-            ttl = ttl,
-          }})
-        defined_hosts[name..":".._M.TYPE_AAAA] = true
-        -- do not overwrite the A success-type unless AAAA is preferred
-        if ip_preference == "AAAA" or not cachegetsuccess(name) then
-          cachesetsuccess(name, _M.TYPE_AAAA)
-        end
-        log(log_DEBUG, "adding AAAA-record from 'hosts' file: ",name, " = ", address.ipv6)
-      end
+      log(log_DEBUG, "adding AAAA-record from 'hosts' file: ",name, " = ", address.ipv6)
     end
   end
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -391,34 +391,53 @@ _M.init = function(options)
   local ttl = 10*365*24*60*60  -- use ttl of 10 years for hostfile entries
   for name, address in pairs(hosts) do
     name = string_lower(name)
-    if address.ipv4 then 
+    if address.ipv4_port or address.ipv6_port then
+      -- entry with a port number, create SRV
       cacheinsert({{  -- NOTE: nested list! cache is a list of lists
           name = name,
-          address = address.ipv4,
-          type = _M.TYPE_A,
+          target = address.ipv4 or address.ipv6,
+          port = address.ipv4_port or address.ipv6_port,
+          type = _M.TYPE_SRV,
           class = 1,
           ttl = ttl,
+          priority = 20,  -- arbitrary...
+          weight = 10,    -- arbitrary...
         }})
-      defined_hosts[name..":".._M.TYPE_A] = true
-      -- cache is empty so far, so no need to check for the ip_preference
-      -- field here, just set ipv4 as success-type.
-      cachesetsuccess(name, _M.TYPE_A)
-      log(log_DEBUG, "adding from 'hosts' file: ",name, " = ", address.ipv4)
-    end
-    if address.ipv6 then 
-      cacheinsert({{  -- NOTE: nested list! cache is a list of lists
-          name = name,
-          address = address.ipv6,
-          type = _M.TYPE_AAAA,
-          class = 1,
-          ttl = ttl,
-        }})
-      defined_hosts[name..":".._M.TYPE_AAAA] = true
-      -- do not overwrite the A success-type unless AAAA is preferred
-      if ip_preference == "AAAA" or not cachegetsuccess(name) then
-        cachesetsuccess(name, _M.TYPE_AAAA)
+      defined_hosts[name..":".._M.TYPE_SRV] = true
+      cachesetsuccess(name, _M.TYPE_SRV)
+      log(log_DEBUG, "adding SRV-record from 'hosts' file: ",name, " = ",
+        address.ipv6 or address.ipv4, ":", address.ipv6_port or address.ipv4_port)
+    else
+      -- entry without a port number, create A or AAAA
+      if address.ipv4 then
+        cacheinsert({{  -- NOTE: nested list! cache is a list of lists
+            name = name,
+            address = address.ipv4,
+            type = _M.TYPE_A,
+            class = 1,
+            ttl = ttl,
+          }})
+        defined_hosts[name..":".._M.TYPE_A] = true
+        -- cache is empty so far, so no need to check for the ip_preference
+        -- field here, just set ipv4 as success-type.
+        cachesetsuccess(name, _M.TYPE_A)
+        log(log_DEBUG, "adding A-record from 'hosts' file: ",name, " = ", address.ipv4)
       end
-      log(log_DEBUG, "adding from 'hosts' file: ",name, " = ", address.ipv6)
+      if address.ipv6 then
+        cacheinsert({{  -- NOTE: nested list! cache is a list of lists
+            name = name,
+            address = address.ipv6,
+            type = _M.TYPE_AAAA,
+            class = 1,
+            ttl = ttl,
+          }})
+        defined_hosts[name..":".._M.TYPE_AAAA] = true
+        -- do not overwrite the A success-type unless AAAA is preferred
+        if ip_preference == "AAAA" or not cachegetsuccess(name) then
+          cachesetsuccess(name, _M.TYPE_AAAA)
+        end
+        log(log_DEBUG, "adding AAAA-record from 'hosts' file: ",name, " = ", address.ipv6)
+      end
     end
   end
 

--- a/src/resty/dns/utils.lua
+++ b/src/resty/dns/utils.lua
@@ -50,10 +50,8 @@ _M.MAXSEARCH = 6
 -- Does not check for correctness of ip addresses nor hostnames. Might return
 -- `nil + error` if the file cannot be read.
 --
--- __NOTE 1__: All output will be normalized to lowercase, IPv6 addresses will
+-- __NOTE__: All output will be normalized to lowercase, IPv6 addresses will
 -- always be returned in brackets.
--- __NOTE 2__: Port numbers are supported as an extension when parsing (a custom)
--- hosts file
 -- @param filename (optional) Filename to parse, or a table with the file 
 -- contents in lines (defaults to `'/etc/hosts'` if omitted)
 -- @return 1; reverse lookup table, ip addresses (table with `ipv4` and `ipv6` 
@@ -85,12 +83,12 @@ _M.parseHosts = function(filename)
     line = line:lower()
     local data, comments = line:match(PATT_COMMENT)
     if data then
-      local ip, hosts, port, family, name
+      local ip, hosts, family, name, _
       -- parse the line
       ip, hosts = data:match(PATT_IP_HOST)
       -- parse and validate the ip address
       if ip then
-        name, port, family = _M.parseHostname(ip)
+        name, _, family = _M.parseHostname(ip)
         if family ~= "ipv4" and family ~= "ipv6" then
           ip = nil  -- not a valid IP address
         else
@@ -99,7 +97,7 @@ _M.parseHosts = function(filename)
       end
       -- add the names
       if ip and hosts then
-        local entry = { ip = ip, family = family, port = port }
+        local entry = { ip = ip, family = family }
         local key = "canonical"
         for host in hosts:gmatch("%S+") do
           entry[key] = host
@@ -109,11 +107,7 @@ _M.parseHosts = function(filename)
             rev = {}
             reverse[host] = rev
           end
-          if not rev[family] then
-            -- do not overwrite, first one wins
-            rev[family] = ip
-            rev[family .. "_port"] = port
-          end
+          rev[family] = rev[family] or ip -- do not overwrite, first one wins
         end
         tinsert(result, entry)
       end

--- a/src/resty/dns/utils.lua
+++ b/src/resty/dns/utils.lua
@@ -22,7 +22,7 @@ local time = ngx.now
 -- 2nd capture is the comment after the # or ;
 local PATT_COMMENT = "^([^#;]+)[#;]*(.*)$"
 -- Splits a string in IP and hostnames part, drops leading/trailing whitespace
-local PATT_IP_HOST = "^%s*([%x%.%:]+)%s+(%S.-%S)%s*$"
+local PATT_IP_HOST = "^%s*([%[%]%x%.%:]+)%s+(%S.-%S)%s*$"
 
 local _DEFAULT_HOSTS = "/etc/hosts"              -- hosts filename to use when omitted
 local _DEFAULT_RESOLV_CONF = "/etc/resolv.conf"  -- resolv.conf default filename
@@ -47,10 +47,13 @@ _M.MAXSEARCH = 6
 -- @section parsing
 
 --- Parses a `hosts` file or table.
--- Does not check for correctness of ip addresses nor hostnames (hostnames will 
--- be forced to lowercase). Might return `nil + error` if the file cannot be read.
+-- Does not check for correctness of ip addresses nor hostnames. Might return
+-- `nil + error` if the file cannot be read.
 --
--- __NOTE__: All hostnames and aliases will be returned in lowercase.
+-- __NOTE 1__: All output will be normalized to lowercase, IPv6 addresses will
+-- always be returned in brackets.
+-- __NOTE 2__: Port numbers are supported as an extension when parsing (a custom)
+-- hosts file
 -- @param filename (optional) Filename to parse, or a table with the file 
 -- contents in lines (defaults to `'/etc/hosts'` if omitted)
 -- @return 1; reverse lookup table, ip addresses (table with `ipv4` and `ipv6` 
@@ -78,14 +81,25 @@ _M.parseHosts = function(filename)
   end
   local result = {}
   local reverse = {}
-  for _,line in ipairs(lines) do 
+  for _, line in ipairs(lines) do
+    line = line:lower()
     local data, comments = line:match(PATT_COMMENT)
     if data then
-      local ip, hosts = data:match(PATT_IP_HOST)
+      local ip, hosts, port, family, name
+      -- parse the line
+      ip, hosts = data:match(PATT_IP_HOST)
+      -- parse and validate the ip address
+      if ip then
+        name, port, family = _M.parseHostname(ip)
+        if family ~= "ipv4" and family ~= "ipv6" then
+          ip = nil  -- not a valid IP address
+        else
+          ip = name
+        end
+      end
+      -- add the names
       if ip and hosts then
-        hosts = hosts:lower()
-        local family = ip:find(":",1, true) and "ipv6" or "ipv4"
-        local entry = { ip = ip, family = family }
+        local entry = { ip = ip, family = family, port = port }
         local key = "canonical"
         for host in hosts:gmatch("%S+") do
           entry[key] = host
@@ -95,7 +109,11 @@ _M.parseHosts = function(filename)
             rev = {}
             reverse[host] = rev
           end
-          rev[family] = rev[family] or ip -- do not overwrite, first one wins
+          if not rev[family] then
+            -- do not overwrite, first one wins
+            rev[family] = ip
+            rev[family .. "_port"] = port
+          end
         end
         tinsert(result, entry)
       end


### PR DESCRIPTION
Additionally relaxes parsing to also allow for port numbers (in
custom hosts files). The DNS client will insert those entries
as SRV records in its cache (other entries will be A or AAAA
type records)