### PR TITLE
fix(client) prevent overwriting CNAME data in the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 - Fix: properly recognize IPv6 in square brackets from the /etc/hosts file.
 - Fix: do not set success-type to types we're not looking for. Fixes
   [Kong issue #3210](https://github.com/Kong/kong/issues/3210).
+- Fix: do not overwrite stale data in the client cache with empty records
 
 ### 1.0.0 (14-Dec-2017) Fixes and IPv6
 


### PR DESCRIPTION
This can occur when a nameserver is configured to NOT reply to CNAME
queries. The empty result might overwrite the proper record that
was delivered along side an A query. This can only happen when
the data is stale, as only then individual refresh queries are send.