### PR TITLE
fix(client) clearly mark client errors as such

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 - BREAKING: improved performance and memory footprint for large balancers.
   80-85% less memory will be used, while creation time dropped by 85-90%. Since
   the `host:getPeer()` function signature changed, this is a breaking change.
+- Change: BREAKING the errors for cache-only lookup failures and empty records
+  have been changed.
 - Fix: do not fail initialization without nameservers. 
 - Fix: properly recognize IPv6 in square brackets from the /etc/hosts file.
 - Fix: do not set success-type to types we're not looking for. Fixes

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -6,6 +6,7 @@ local pretty = require("pl.pretty").write
 -- empty records and not found errors should be identical, hence we
 -- define a constant for that error message
 local NOT_FOUND_ERROR = "dns server error: 3 name error"
+local EMPTY_ERROR = "dns client error: 101 empty record received"
 
 local gettime, sleep
 if ngx then
@@ -536,7 +537,7 @@ describe("DNS client", function()
 
     local answers, err, r, history = client.resolve(host, {qtype = typ})
     assert.is_nil(answers)  -- returns nil
-    assert.equal(NOT_FOUND_ERROR, err)
+    assert.equal(EMPTY_ERROR, err)
   end)
 
   it("fetching non-existing records", function()


### PR DESCRIPTION
This eases debugging since the old error messages might have led
people to think the server generated the error.

fixes #37