### PR TITLE
 Fixes a bug for replacing stale data in the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 - Fix: properly recognize IPv6 in square brackets from the /etc/hosts file.
 - Fix: do not set success-type to types we're not looking for. Fixes
   [Kong issue #3210](https://github.com/Kong/kong/issues/3210).
+- Fix: store records from the additional section in cache
 - Fix: do not overwrite stale data in the client cache with empty records
 
 ### 1.0.0 (14-Dec-2017) Fixes and IPv6

--- a/extra/analyze.lua
+++ b/extra/analyze.lua
@@ -1,0 +1,165 @@
+-- script to analyze logs.
+-- If extensive debug is enabled (the long-comments) in the client, then
+-- a lot of data will be logged as json.
+-- this script will update a log file by expanding the json, it will insert
+-- original line numbers for each line to track with the original log.
+-- Optionally filters and token replacements can be made.
+-- check the TODO comments in the code below.
+
+
+
+-- The input log-file name, extension must be ".log", but that extension must
+-- be omitted here
+-- TODO: update
+local filename = "log_error_2018-02-16"
+
+-- The output filename, same as the input name, but with this suffix:
+-- TODO: update
+local output = filename .. "_out3.log"
+
+
+
+filename = filename .. ".log"
+local indent = require("pl.text").indent
+local decode = require("cjson.safe").decode
+local readfile = require("pl.utils").readfile
+local readlines = require("pl.utils").readlines
+local writefile = require("pl.utils").writefile
+local pretty = require("pl.pretty").write
+
+
+local file = assert(readfile(filename))
+local tokens = {}
+local list = {}
+
+
+
+-- Look for, and list tokens.
+-- In case the log has been adapted and tokens inserted for sensitive data
+-- this allows to replace the tokens again with original-type data
+-- and also prevent breaking the JSON serialization
+
+-- TODO: update pattern to match a token
+local token_match = "(%<%<.-%>%>)"
+
+
+local i = 0
+for token in file:gmatch(token_match) do
+  if not tokens[token] then
+    tokens[token] = 1
+    table.insert(list, token)
+  else
+    tokens[token] = tokens[token] + 1
+  end
+end
+
+-- display the tokens found
+table.sort(list)
+print("local substitutes = {")
+for _, token in ipairs(list) do
+  print('  ["'..token..'"] = nil,    -- ', tokens[token])
+end
+print("}")
+
+
+
+-- Update tokens.
+-- here we provide a list of replacement strings for the tokens found
+-- TODO: update
+local substitutes = {
+--  ["<< PORT>>"] = "8080",    -- 1384
+--  ["<<HOST ALIAS 1>>"] = nil,    -- 7
+--  ["<<HOST ALIAS 2>>"] = "some.hostname",    -- 1619
+--  ["<<HOSTNAME 1>>"] = "internal.hostname1",    -- 5773
+--  ["<<IP ADDRESS 10>>"] = "10.10.10.10",    -- 206
+--  ["<<IP ADDRESS 11>>"] = "10.10.10.11",    -- 206
+--  ["<<IP ADDRESS 12>>"] = "10.10.10.12",    -- 3201
+--  ["<<IP ADDRESS 13>>"] = "10.10.10.13",    -- 224
+--  ["<<IP ADDRESS 1>>"] = "10.10.10.1",    -- 2
+--  ["<<IP ADDRESS 2>>"] = "10.10.10.2",    -- 2986
+--  ["<<IP ADDRESS 3>>"] = "10.10.10.3",    -- 810
+--  ["<<IP ADDRESS 7>>"] = "10.10.10.7",    -- 258
+--  ["<<IP ADDRESS 8>>"] = "10.10.10.8",    -- 210
+--  ["<<IP ADDRESS 9>>"] = "10.10.10.9",    -- 252
+--  ["<<UPSTREAM ALIAS 1>>"] = "external.name1",    -- 9606
+--  ["<<UPSTREAM ALIAS 2>>"] = "external.name2",    -- 9979
+--  ["<<UPSTREAM ALIAS 3.1>>"] = "external.name3-1",    -- 13655
+--  ["<<UPSTREAM ALIAS 3>>"] = "external.name3",    -- 10602
+--  ["<<UPSTREAM ALIAS 4>>"] = "external.name4",    -- 10273
+--  ["<<UPSTREAM HOSTNAME 2>>"] = "internal.hostname2",    -- 2733
+--  ["<<UPSTREAM HOSTNAME 4>>"] = "internal.hostname4",    -- 5927
+--  ["<<UPSTREAM IP 2>>"] = "10.10.11.2",    -- 1380
+--  ["<<UPSTREAM IP 4>>"] = "10.10.10.4",    -- 2998
+--  ["<<UPSTREAM PORT 2>>"] = "8082",    -- 1348
+--  ["<<UPSTREAM PORT 4>>"] = "8084",    -- 2750
+--  ["<<UPSTREAM VIP 3.1>>"] = "internal.hostname3-1",    -- 322
+--  ["<<UPSTREAM VIP 3.2>>"] = nil,    -- 38
+--  ["<<UPSTREAM VIP 3.3>>"] = "internal.hostname3-3",    -- 385
+--  ["<<UPSTREAM VIP 3.4>>"] = "internal.hostname3-4",    -- 394
+--  ["<<UPSTREAM VIP 3.5>>"] = "internal.hostname3-5",    -- 343
+--  ["<<UPSTREAM VIP 3.6>>"] = "internal.hostname3-6",    -- 6563
+--  ["<<UPSTREAM VIP 3.7>>"] = "internal.hostname3-7",    -- 316
+--  ["<<UPSTREAM VIP 3.8>>"] = "internal.hostname3-8",    -- 316
+}
+
+-- escape the tokens, and replace all occurences
+for token, substitute in pairs(substitutes) do
+  l = {}
+  for i = 1, #token do
+    --table.insert(l, "%")
+    table.insert(l, token:sub(i,i))
+  end
+  token = table.concat(l)
+
+  file, l = file:gsub(token, substitute)
+  print(token, " : ", l)    -- print number of replacements
+end
+
+
+-- write output
+writefile(output, file)
+file = nil  -- save memory
+local lines = readlines(output)  -- read again, as lines
+
+
+-- provide a filter to match, only lines matching at least 1 of those filters
+-- will be included
+-- TODO: update
+local matches = {
+--  "external%.name4 ",
+--  "external%.name4:",
+--  "external%.name4$",
+}
+
+local out = {}
+local out_n = 0
+for i = 1, #lines do
+  local line = ("%6.0f "):format(i) .. lines[i]
+  local m = (#matches == 0)
+  for _, patt in ipairs(matches) do
+    if line:match(patt) then
+      m = true
+      break
+    end
+  end
+  if m then
+    local prefix, json = line:match("^(.-)(%{.+%})$")
+    if not json then
+      prefix, json = line:match("^(.-)(%[%{.+%}%])$")
+    end
+    if json then
+      local t, err = assert(decode(json))
+      if t then
+        t = indent(pretty(t), 4)
+        if t:sub(-1,-1) == "\n" then t = t:sub(1,-2) end
+        lines[i] = prefix .. "\n" .. t
+      end
+    else
+      lines[i] = line
+    end
+    out_n = out_n + 1
+    out[out_n] = lines[i]
+  end
+end
+
+writefile(output, table.concat(out, "\n"))

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -25,10 +25,14 @@ local semaphore = require("ngx.semaphore").new
 local lrucache = require("resty.lrucache")
 local resolver = require("resty.dns.resolver")
 local deepcopy = require("pl.tablex").deepcopy
+---[[
+local json = require("cjson").encode
+--]]
 local time = ngx.now
-local ngx_log = ngx.log
-local log_WARN = ngx.WARN
-local log_DEBUG = ngx.DEBUG
+local log = ngx.log
+local WARN = ngx.WARN
+local DEBUG = ngx.DEBUG
+local PREFIX = "[dns-client] "
 local timer_at = ngx.timer.at
 
 local math_min = math.min
@@ -73,9 +77,6 @@ end
 -- insert our own special value for "last success"
 _M.TYPE_LAST = -1
 
-local function log(level, ...)
-  return ngx_log(level, "[dns-client] ", ...)
-end
 
 -- ==============================================
 --    In memory DNS cache
@@ -109,7 +110,18 @@ local cachelookup = function(qname, qtype)
     cached.touch = now
     if (cached.expire < now) then
       cached.expired = true
+      ---[[
+      log(DEBUG, PREFIX, "cache get (stale): ", key, " ", tostring(cached), " ", json(cached))
+      --]]
+    else
+      ---[[
+      log(DEBUG, PREFIX, "cache get: ", key, " ", tostring(cached), " ", json(cached))
+      --]]
     end
+  else
+    ---[[
+    log(DEBUG, PREFIX, "cache get (miss): ", key)
+    --]]
   end
 
   return cached
@@ -148,6 +160,9 @@ local cacheinsert = function(entry, qname, qtype)
       -- an error, but no 'name error' (3)
       if (cachelookup(qname, qtype) or empty)[1] then
         -- we still have a stale record with data, so we're not replacing that
+        ---[[
+        log(DEBUG, PREFIX, "cache set (skip on name error): ", key, " ", tostring(entry), " ", json(entry))
+        --]]
         return
       end
       ttl = badTtl
@@ -162,6 +177,9 @@ local cacheinsert = function(entry, qname, qtype)
       -- empty record
       if (cachelookup(qname, qtype) or empty)[1] then
         -- we still have a stale record with data, so we're not replacing that
+        ---[[
+        log(DEBUG, PREFIX, "cache set (skip on empty): ", key, " ", tostring(entry), " ", json(entry))
+        --]]
         return
       end
       ttl = emptyTtl
@@ -174,6 +192,9 @@ local cacheinsert = function(entry, qname, qtype)
     entry.expire = now + ttl
     entry.expired = false
     lru_ttl = ttl + staleTtl
+    ---[[
+    log(DEBUG, PREFIX, "cache set (new): ", key, " ", tostring(entry), " ", json(entry))
+    --]]
 
   else
     -- an existing record reinserted (under a shortname for example)
@@ -181,11 +202,17 @@ local cacheinsert = function(entry, qname, qtype)
     ttl = entry.ttl
     key = (qtype or e1.type) .. ":" .. (qname or e1.name)
     lru_ttl = entry.expire - now + staleTtl
+    ---[[
+    log(DEBUG, PREFIX, "cache set (existing): ", key, " ", tostring(entry), " ", json(entry))
+    --]]
   end
 
   if lru_ttl <= 0 then
     -- item is already expired, so we do not add it
     dnscache:delete(key)
+    ---[[
+    log(DEBUG, PREFIX, "cache set (delete on expired): ", key, " ", tostring(entry), " ", json(entry))
+    --]]
     return
   end
 
@@ -233,10 +260,16 @@ local function cachesetsuccess(qname, qtype)
   if not validType then
     -- the qtype is not in the list, so we're not setting it as the
     -- success type
+    ---[[
+    log(DEBUG, PREFIX, "cache set success (skip on bad type): ", qname, ", ", qtype)
+    --]]
     return false
   end
 
   dnscache:set(qname, qtype)
+  ---[[
+  log(DEBUG, PREFIX, "cache set success: ", qname, " = ", qtype)
+  --]]
   return true
 end
 
@@ -377,12 +410,14 @@ local poolMaxRetry
 -- )
 _M.init = function(options)
   
-  log(log_DEBUG, "(re)configuring dns client")
+  log(DEBUG, PREFIX, "(re)configuring dns client")
   local resolv, hosts, err
   options = options or {}
   staleTtl = options.staleTtl or 4
+  log(DEBUG, PREFIX, "staleTtl = ", staleTtl)
   cacheSize = options.cacheSize or 10000  -- default set here to be able to reset the cache
   noSynchronisation = options.noSynchronisation
+  log(DEBUG, PREFIX, "noSynchronisation = ", tostring(noSynchronisation))
 
   dnscache = lrucache.new(cacheSize)  -- clear cache on (re)initialization
   defined_hosts = {}  -- reset hosts hash table
@@ -401,7 +436,7 @@ _M.init = function(options)
     typeOrder[i] = _M["TYPE_"..t]
   end
   assert(#typeOrder > 0, "Invalid order list; cannot be empty")
-  log(log_DEBUG, "query order: ", table.concat(order,", "))
+  log(DEBUG, PREFIX, "query order = ", table_concat(order,", "))
 
   
   -- Deal with the `hosts` file
@@ -413,7 +448,7 @@ _M.init = function(options)
     hosts, err = utils.parseHosts(hostsfile)  -- results will be all lowercase!
     if not hosts then return hosts, err end
   else
-    log(log_WARN, "Hosts file not found: "..tostring(hostsfile))  
+    log(WARN, PREFIX, "Hosts file not found: "..tostring(hostsfile))
     hosts = {}
   end
 
@@ -433,7 +468,7 @@ _M.init = function(options)
       -- cache is empty so far, so no need to check for the ip_preference
       -- field here, just set ipv4 as success-type.
       cachesetsuccess(name, _M.TYPE_A)
-      log(log_DEBUG, "adding A-record from 'hosts' file: ",name, " = ", address.ipv4)
+      log(DEBUG, PREFIX, "adding A-record from 'hosts' file: ",name, " = ", address.ipv4)
     end
     if address.ipv6 then 
       cacheinsert({{  -- NOTE: nested list! cache is a list of lists
@@ -448,7 +483,7 @@ _M.init = function(options)
       if ip_preference == "AAAA" or not cachegetsuccess(name) then
         cachesetsuccess(name, _M.TYPE_AAAA)
       end
-      log(log_DEBUG, "adding AAAA-record from 'hosts' file: ",name, " = ", address.ipv6)
+      log(DEBUG, PREFIX, "adding AAAA-record from 'hosts' file: ",name, " = ", address.ipv6)
     end
   end
 
@@ -462,7 +497,7 @@ _M.init = function(options)
     resolv, err = utils.applyEnv(utils.parseResolvConf(resolvconffile))
     if not resolv then return resolv, err end
   else
-    log(log_WARN, "Resolv.conf file not found: "..tostring(resolvconffile))  
+    log(WARN, PREFIX, "Resolv.conf file not found: "..tostring(resolvconffile))
     resolv = {}
   end
   if not resolv.options then resolv.options = {} end
@@ -474,7 +509,7 @@ _M.init = function(options)
       local ip, port, t = utils.parseHostname(address)
       if t == "ipv6" and not options.enable_ipv6 then
         -- should not add this one
-        log(log_DEBUG, "skipping IPv6 nameserver ", port and (ip..":"..port) or ip)
+        log(DEBUG, PREFIX, "skipping IPv6 nameserver ", port and (ip..":"..port) or ip)
       else
         if port then
           options.nameservers[#options.nameservers + 1] = { ip, port }
@@ -486,15 +521,15 @@ _M.init = function(options)
   end
   options.nameservers = options.nameservers or {}
   if #options.nameservers == 0 then
-    log(log_WARN, "Invalid configuration, no valid nameservers found")
+    log(WARN, PREFIX, "Invalid configuration, no valid nameservers found")
   else
     for _, r in ipairs(options.nameservers) do
-      log(log_DEBUG, "nameserver ", type(r) == "table" and (r[1]..":"..r[2]) or r)
+      log(DEBUG, PREFIX, "nameserver ", type(r) == "table" and (r[1]..":"..r[2]) or r)
     end
   end
   
   options.retrans = options.retrans or resolv.options.attempts or 5 -- 5 is openresty default
-  log(log_DEBUG, "attempts ", options.retrans)
+  log(DEBUG, PREFIX, "attempts = ", options.retrans)
   
   if not options.timeout then
     if resolv.options.timeout then
@@ -503,19 +538,21 @@ _M.init = function(options)
       options.timeout = 2000  -- 2000 is openresty default
     end
   end
-  log(log_DEBUG, "timeout ", options.timeout, " ms")
+  log(DEBUG, PREFIX, "timeout = ", options.timeout, " ms")
 
   -- setup the search order
   options.ndots = options.ndots or resolv.options.ndots or 1
+  log(DEBUG, PREFIX, "ndots = ", options.ndots)
   options.search = options.search or resolv.search or { resolv.domain }
+  log(DEBUG, PREFIX, "search = ", table_concat(options.search,", "))
   
   
   -- other options
   
   badTtl = options.badTtl or 1
-  log(log_DEBUG, "badTtl ", badTtl, " s")
+  log(DEBUG, PREFIX, "badTtl = ", badTtl, " s")
   emptyTtl = options.emptyTtl or 30
-  log(log_DEBUG, "emptyTtl ", emptyTtl, " s")
+  log(DEBUG, PREFIX, "emptyTtl = ", emptyTtl, " s")
   
   -- options.no_recurse = -- not touching this one for now
   
@@ -528,9 +565,10 @@ _M.init = function(options)
 end
 
 
--- removes non-requested results, updates the cache
+-- Removes non-requested results, updates the cache.
+-- Parameter `answers` is updated in-place.
 -- @return `true`
-local function parseQuery(qname, qtype, answers, try_list)
+local function parseAnswer(qname, qtype, answers, try_list)
 
   -- check the answers and store them in the cache
   -- eg. A, AAAA, SRV records may be accompanied by CNAME records
@@ -594,7 +632,7 @@ local function individualQuery(qname, r_opts, try_list)
     return result, err, try_list
   end
 
-  parseQuery(qname, r_opts.qtype, result, try_list)
+  parseAnswer(qname, r_opts.qtype, result, try_list)
 
   return result, nil, try_list
 end
@@ -610,10 +648,25 @@ local function executeQuery(premature, item)
   if not r then
     item.result, item.err = r, "failed to create a resolver: " .. err
   else
+    ---[[
+    log(DEBUG, PREFIX, "Query executing: ", item.qname, ":", item.r_opts.qtype, " ", tostring(item))
+    --]]
     try_status(item.try_list, "querying")
     item.result, item.err = r:query(item.qname, item.r_opts)
     if item.result then
-      parseQuery(item.qname, item.r_opts.qtype, item.result, item.try_list)
+      ---[[
+      log(DEBUG, PREFIX, "Query answer: ", item.qname, ":", item.r_opts.qtype, " ", tostring(item),
+              " answer:", json(item.result))
+      --]]
+      parseAnswer(item.qname, item.r_opts.qtype, item.result, item.try_list)
+      ---[[
+      log(DEBUG, PREFIX, "Query parsed answer: ", item.qname, ":", item.r_opts.qtype, " ", tostring(item),
+              " answer:", json(item.result))
+      --]]
+    else
+      ---[[
+      log(DEBUG, PREFIX, "Query error: ", item.qname, ":", item.r_opts.qtype, " err=", tostring(err))
+      --]]
     end
   end
 
@@ -638,6 +691,9 @@ local function asyncQuery(qname, r_opts, try_list)
   local key = qname..":"..r_opts.qtype
   local item = queue[key]
   if item then
+    ---[[
+    log(DEBUG, PREFIX, "Query async (exists): ", key, " ", tostring(item))
+    --]]
     try_status(try_list, "in progress (async)")
     return item    -- already in progress, return existing query
   end
@@ -656,6 +712,9 @@ local function asyncQuery(qname, r_opts, try_list)
     queue[key] = nil
     return nil, "asyncQuery failed to create timer: "..err
   end
+  ---[[
+  log(DEBUG, PREFIX, "Query async (scheduled): ", key, " ", tostring(item))
+  --]]
   try_status(try_list, "scheduled")
 
   return item
@@ -674,15 +733,22 @@ end
 local function syncQuery(qname, r_opts, try_list, count)
   local key = qname..":"..r_opts.qtype
   local item = queue[key]
+  count = count or 1
 
   -- if nothing is in progress, we start a new async query
   if not item then
     local err
     item, err = asyncQuery(qname, r_opts, try_list)
+    ---[[
+    log(DEBUG, PREFIX, "Query sync (new): ", key, " ", tostring(item)," count=", count)
+    --]]
     if not item then
       return item, err, try_list
     end
   else
+    ---[[
+    log(DEBUG, PREFIX, "Query sync (exists): ", key, " ", tostring(item)," count=", count)
+    --]]
     try_status(try_list, "in progress (sync)")
   end
 
@@ -691,14 +757,20 @@ local function syncQuery(qname, r_opts, try_list, count)
   if ok and item.result then
     -- we were released, and have a query result from the
     -- other thread, so all is well, return it
+    ---[[
+    log(DEBUG, PREFIX, "Query sync result: ", key, " ", tostring(item),
+           " result: ", json({ result = item.result, err = item.err}))
+    --]]
     return item.result, item.err, try_list
   end
 
   -- there was an error, either a semaphore timeout, or a lookup error
   -- go retry
-  count = count or 1
   try_status(try_list, "try "..count.." error: "..(item.err or err or "unknown"))
   if count > poolMaxRetry then
+    ---[[
+    log(DEBUG, PREFIX, "Query sync (fail): ", key, " ", tostring(item)," retries exceeded. count=", count)
+    --]]
     return nil, "dns lookup pool exceeded retries (" ..
                 tostring(poolMaxRetry) .. "): "..tostring(item.err or err),
                 try_list
@@ -707,6 +779,9 @@ local function syncQuery(qname, r_opts, try_list, count)
   -- don't block on the same thread again, so remove it from the queue
   if queue[key] == item then queue[key] = nil end
 
+  ---[[
+  log(DEBUG, PREFIX, "Query sync (fail): ", key, " ", tostring(item)," retrying. count=", count)
+  --]]
   return syncQuery(qname, r_opts, try_list, count + 1)
 end
 
@@ -726,6 +801,9 @@ local function lookup(qname, r_opts, dnsCacheOnly, try_list)
     --not found in cache
     if dnsCacheOnly then
       -- we can't do a lookup, so return an error
+      ---[[
+      log(DEBUG, PREFIX, "Lookup, cache only failure: ", qname, " = ", r_opts.qtype)
+      --]]
       try_list = try_add(try_list, qname, r_opts.qtype, "cache only lookup failed")
       return {
         errcode = 100,

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -594,11 +594,7 @@ local function parseAnswer(qname, qtype, answers, try_list)
   end
   if next(others) then
     for _, lst in pairs(others) do
-      -- only store if not already cached (this is only a 'by-product')
-      -- or replace it if the cache contains an error
-      if #(cachelookup(lst[1].name, lst[1].type) or empty) == 0 then
-        cacheinsert(lst)
-      end
+      cacheinsert(lst)
       -- set success-type, only if not set (this is only a 'by-product')
       if not cachegetsuccess(lst[1].name) then
         cachesetsuccess(lst[1].name, lst[1].type)


### PR DESCRIPTION
records from the additional section would not be stored in the
cache when there already was a cache entry. This also means that
stale data was not replaced. The bug surfaced when a dns server
would not respond to CNAME queries, but only provide that data
alongside an A query.

To track the bug extensive logging was added (to be enabled manually),
and a script to re-format those logs.