### PR TITLE
fix(balancer) report default port for SRV record with port=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
 - Fix: the round robin scheme for the balanceer starts at a randomized position
   to prevent all workers from starting with the same peer.
+- Fix: the balancer no longer returns `port = 0` for SRV records without a
+  port, the default port is now returned.
 
 ### 2.0.0 (22-Feb-2018) Major performance improvement (balancer) and bugfixes
 

--- a/spec/balancer_spec.lua
+++ b/spec/balancer_spec.lua
@@ -564,6 +564,19 @@ describe("Loadbalancer", function()
         assert.is_nil(ok)
         assert.equals("no peer found by name 'mashape.com' and address mashape1.com:80", err)
       end)
+      it("SRV target with port=0 returns the default port", function()
+        local b = check_balancer(balancer.new { dns = client })
+        dnsA({
+          { name = "mashape1.com", address = "12.34.56.78" },
+        })
+        dnsSRV({
+          { name = "mashape.com", target = "mashape1.com", port = 0, weight = 5 },
+        })
+        b:addHost("mashape.com", 80, 10)
+        local ip, port = b:getPeer()
+        assert.equals("12.34.56.78", ip)
+        assert.equals(80, port)
+      end)
     end)
 
   end)

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -516,7 +516,7 @@ function objHost:addAddress(entry)
   local addresses = self.addresses
   addresses[#addresses+1] = newAddress(
     entry.address or entry.target,
-    entry.port or self.port,
+    (entry.port ~= 0 and entry.port) or self.port,
     weight or self.nodeWeight,
     self
   )


### PR DESCRIPTION
When SRV records do not carry a port (value 0), then the balancer
will now report the default port (the port used when adding the
target to the balancer).