### PR TITLE
fix(client) do not accept ipv6 resolvers with a scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
   to prevent all workers from starting with the same peer.
 - Fix: the balancer no longer returns `port = 0` for SRV records without a
   port, the default port is now returned.
+- Fix: ipv6 nameservers with a scope in their address are not supported. This
+  fix will simply skip them instead of throwing errors upon resolving. Fixes
+  [issue 43][https://github.com/Kong/lua-resty-dns-client/issues/43].
 
 ### 2.0.0 (22-Feb-2018) Major performance improvement (balancer) and bugfixes
 

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -73,6 +73,18 @@ describe("DNS client", function()
       assert.has.no.error(function() client.init( {nameservers = {}, resolvConf = {} } ) end)
     end)
 
+    it("skips ipv6 nameservers with scopes", function()
+      assert.has.no.error(function() client.init({
+              enable_ipv6 = true,
+              resolvConf = {"nameserver [fe80::1%enp0s20f0u1u1]"},
+            })
+          end)
+      local ip, port = client.toip("thijsschreijer.nl")
+      assert.is_nil(ip)
+      assert.not_matches([[failed to parse host name "[fe80::1%enp0s20f0u1u1]": invalid IPv6 address]], port, nil, true)
+      assert.matches([[failed to create a resolver: no nameservers specified]], port, nil, true)
+    end)
+
     it("fails with order being empty", function()
       -- fails with an empty one
       assert.has.error(

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -528,6 +528,9 @@ _M.init = function(options)
       if t == "ipv6" and not options.enable_ipv6 then
         -- should not add this one
         log(DEBUG, PREFIX, "skipping IPv6 nameserver ", port and (ip..":"..port) or ip)
+      elseif t == "ipv6" and ip:find([[%]], nil, true) then
+        -- ipv6 with a scope
+        log(DEBUG, PREFIX, "skipping IPv6 nameserver (scope not supported) ", port and (ip..":"..port) or ip)
       else
         if port then
           options.nameservers[#options.nameservers + 1] = { ip, port }


### PR DESCRIPTION
Provide a nice log message and skip, instead of erroring out

fixes #43