### PR TITLE
fix(client) always inject localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 - Added: a new option `validTtl` that, if set, will forcefully override the
   `ttl` value of any valid answer received. [Issue 48](https://github.com/Kong/lua-resty-dns-client/issues/48).
 - Fix: remove multiline log entries, now encoded as single-line json. [Issue 52](https://github.com/Kong/lua-resty-dns-client/issues/52).
+- Fix: always inject a `localhost` value, even if not in `/etc/hosts`. [Issue 54](https://github.com/Kong/lua-resty-dns-client/issues/54).
 
 ### 2.1.0 (21-May-2018) Fixes
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -485,6 +485,14 @@ _M.init = function(options)
     hosts = {}
   end
 
+  -- treat `localhost` special, by always defining it, RFC 6761: Section 6.3.3
+  if not hosts.localhost then
+    hosts.localhost = {
+      ipv4 = "127.0.0.1",
+      ipv6 = "[::1]",
+    }
+  end
+
   -- Populate the DNS cache with the hosts (and aliasses) from the hosts file.
   local ttl = 10*365*24*60*60  -- use ttl of 10 years for hostfile entries
   for name, address in pairs(hosts) do


### PR DESCRIPTION
Treat the localhost name special by always injecting it, according
to RFC 6761: Section 6.3.3

fixes #50