### PR TITLE
fix(logging) encode try-list as json and no longer use new-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
 - Added: a new option `validTtl` that, if set, will forcefully override the
   `ttl` value of any valid answer received. [Issue 48](https://github.com/Kong/lua-resty-dns-client/issues/48).
+- Fix: remove multiline log entries, now encoded as single-line json. [Issue 52](https://github.com/Kong/lua-resty-dns-client/issues/52).
 
 ### 2.1.0 (21-May-2018) Fixes
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -311,10 +311,11 @@ local try_list_mt = {
   __tostring = function(self)
     local l, i = {}, 0
     for _, entry in ipairs(self) do
+      l[i] = '","'
       l[i+1] = entry.qname
       l[i+2] = ":"
       l[i+3] = entry.qtype or "(na)"
-      local m = tostring(entry.msg)
+      local m = tostring(entry.msg):gsub('"',"'")
       if m == "" then
         i = i + 4
       else
@@ -322,10 +323,9 @@ local try_list_mt = {
         l[i+5] = m
         i = i + 6
       end
-      l[i]="\n"
     end
     -- concatenate result and encode as json array
-    return '[ "' .. table_concat(l, "", 1, i-1):gsub('"',"'"):gsub("\n",'", "') .. '" ]'
+    return '["' .. table_concat(l) .. '"]'
   end
 }
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -324,7 +324,8 @@ local try_list_mt = {
       end
       l[i]="\n"
     end
-    return table_concat(l)
+    -- concatenate result and encode as json array
+    return '[ "' .. table_concat(l, "", 1, i-1):gsub('"',"'"):gsub("\n",'", "') .. '" ]'
   end
 }
 


### PR DESCRIPTION
New-line characters in the logging are impossible to parse
correctly so should be prevented.

fixes #52