### PR TITLE
fix(balancer) fix accidental ttl=0 switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
   `ttl` value of any valid answer received. [Issue 48](https://github.com/Kong/lua-resty-dns-client/issues/48).
 - Fix: remove multiline log entries, now encoded as single-line json. [Issue 52](https://github.com/Kong/lua-resty-dns-client/issues/52).
 - Fix: always inject a `localhost` value, even if not in `/etc/hosts`. [Issue 54](https://github.com/Kong/lua-resty-dns-client/issues/54).
+- Fix: added a workaround for Amazon Route 53 nameservers replying with a
+  `ttl=0` whilst the record has a non-0 ttl. [Issue 56](https://github.com/Kong/lua-resty-dns-client/issues/56).
 
 ### 2.1.0 (21-May-2018) Fixes
 


### PR DESCRIPTION
See https://github.com/Kong/lua-resty-dns-client/issues/51

Some servers will report ttl=0 when they are on the very edge
of their own cached ttl. This should never happen for a record
that has a non-0 ttl.

This fix makes sure we require ttl=0 reported twice in a row before
we switch the loadbalancer.

Fixes #51