### PR TITLE
feat(client) add option to override ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ History
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
+### 2.2.0 (xx-Sep-2018) unreleased...
+
+- Added: a new option `validTtl` that, if set, will forcefully override the
+  `ttl` value of any valid answer received. [Issue 48](https://github.com/Kong/lua-resty-dns-client/issues/48).
+
 ### 2.1.0 (21-May-2018) Fixes
 
 - Fix: the round robin scheme for the balanceer starts at a randomized position


### PR DESCRIPTION
Implements a new option `validTtl` that, if given, overrides the
ttl of any valid answer received from the name server.

closes #48