### PR TITLE
refactor(balancer) split dns and balancer logic

### DIFF
--- a/lua-resty-dns-client-2.2.0-1.rockspec
+++ b/lua-resty-dns-client-2.2.0-1.rockspec
@@ -17,6 +17,7 @@ dependencies = {
   "lua >= 5.1, < 5.4",
   "penlight > 1.1, < 2.0",
   "lrandom",
+  "lua-resty-timer < 1.0",
 }
 build = {
   type = "builtin",

--- a/spec/balancer_base_spec.lua
+++ b/spec/balancer_base_spec.lua
@@ -1,0 +1,327 @@
+
+local dnscache, client, balancer_base
+
+
+local helpers = require "spec.test_helpers"
+local gettime = helpers.gettime
+local sleep = helpers.sleep
+local dnsSRV = function(...) return helpers.dnsSRV(client, ...) end
+local dnsA = function(...) return helpers.dnsA(client, ...) end
+local dnsAAAA = function(...) return helpers.dnsAAAA(client, ...) end
+local dnsExpire = helpers.dnsExpire
+
+
+describe("[balancer_base]", function()
+
+  local snapshot
+
+  setup(function()
+    _G.package.loaded["dns.client"] = nil -- make sure module is reloaded
+    _G._TEST = true  -- expose internals for test purposes
+    balancer_base = require "resty.dns.balancer_base"
+    client = require "resty.dns.client"
+  end)
+
+
+  before_each(function()
+    assert(client.init {
+      hosts = {},
+      resolvConf = {
+        "nameserver 8.8.8.8"
+      },
+    })
+    dnscache = client.getcache()  -- must be after 'init' call because it is replaced
+    snapshot = assert:snapshot()
+  end)
+
+
+  after_each(function()
+    snapshot:revert()  -- undo any spying/stubbing etc.
+    collectgarbage()
+    collectgarbage()
+  end)
+
+
+
+  describe("event order", function()
+
+    local event_list, b
+
+    setup(function()
+      b = balancer_base.new({
+        dns = client,
+      })
+      local addrInfo = function(addr, event)
+        return {
+          _event = event,
+          address = addr.ip..":"..addr.port,
+          weight = addr.weight,
+          disabled = addr.disabled,
+          available = addr.available,
+        }
+      end
+      local hostInfo = function(host, event)
+        local info = {
+          _event = event,
+          host = host.hostname..":"..host.port,
+          nodeWeight = host.nodeWeight,
+        }
+        for i, addr in ipairs(host.addresses) do
+          info[i] = addrInfo(addr)
+        end
+        return info
+      end
+
+      function b:onAddAddress(addr)
+        table.insert(event_list, addrInfo(addr, "onAddAddress"))
+        self.super.onAddAddress(self, addr)
+      end
+      function b:onRemoveAddress(addr)
+        table.insert(event_list, addrInfo(addr, "onRemoveAddress"))
+        self.super.onRemoveAddress(self, addr)
+      end
+      function b:afterHostUpdate(host)
+        table.insert(event_list, hostInfo(host, "afterHostUpdate"))
+        self.super.afterHostUpdate(self, host)
+      end
+      function b:beforeHostDelete(host)
+        table.insert(event_list, hostInfo(host, "beforeHostDelete"))
+        self.super.beforeHostDelete(self, host)
+      end
+      function b:touch_all()
+        for _, addr in ipairs(self.addresses) do
+          addr:getPeer()  -- will force dns update of expired records
+        end
+      end
+    end)
+
+
+    local record
+    before_each(function()
+      event_list = {}
+      record = dnsSRV({
+        { name = "konghq.com", target = "1.1.1.1", port = 3, weight = 6 },
+        { name = "konghq.com", target = "2.2.2.2", port = 5, weight = 7 },
+      })
+    end)
+
+
+    after_each(function()
+      -- clear all the hosts from the test balancer
+      for _, host in ipairs(b.hosts) do
+        b:removeHost(host.hostname, host.port)
+      end
+    end)
+
+
+
+    it("when adding a host", function()
+      b:addHost("konghq.com", 8000, 100)
+      assert.same({
+        {
+          _event = 'onAddAddress',
+          address = '1.1.1.1:3',
+          available = true,
+          disabled = false,
+          weight = 6
+        }, {
+          _event = 'onAddAddress',
+          address = '2.2.2.2:5',
+          available = true,
+          disabled = false,
+          weight = 7,
+        }, {
+          _event = 'afterHostUpdate',
+          host = 'konghq.com:8000',
+          nodeWeight = 100,
+          {
+            address = '1.1.1.1:3',
+            available = true,
+            disabled = false,
+            weight = 6
+          }, {
+            address = '2.2.2.2:5',
+            available = true,
+            disabled = false,
+            weight = 7,
+          },
+        }
+      }, event_list)
+    end)
+
+
+    it("when removing a host", function()
+      b:addHost("konghq.com", 8000, 100)
+      event_list = {}  -- clear the list so we only get relevant events
+      b:removeHost("konghq.com", 8000)
+      assert.same({
+        {
+          _event = 'beforeHostDelete',
+          host = 'konghq.com:8000',
+          nodeWeight = 100,
+          {                    -- both addresses still here, but disabled!
+            address = '1.1.1.1:3',
+            available = true,
+            disabled = true,   -- marked as disabled!
+            weight = 0,        -- weight reduced to 0!
+          }, {
+            address = '2.2.2.2:5',
+            available = true,
+            disabled = true,   -- marked as disabled!
+            weight = 0,        -- weight reduced to 0!
+          },
+        }, {
+          _event = 'onRemoveAddress',
+          address = '2.2.2.2:5',
+          available = true,
+          disabled = true,   -- marked as disabled!
+          weight = 0,        -- weight reduced to 0!
+        }, {
+          _event = 'onRemoveAddress',
+          address = '1.1.1.1:3',
+          available = true,
+          disabled = true,   -- marked as disabled!
+          weight = 0,        -- weight reduced to 0!
+        },
+      }, event_list)
+    end)
+
+
+    it("when removing a DNS record entry", function()
+      b:addHost("konghq.com", 8000, 100)
+      dnsExpire(record)  -- expire initial record
+      record = dnsSRV({  -- insert a new record, 1 entry removed
+        { name = "konghq.com", target = "1.1.1.1", port = 3, weight = 6 },
+      })
+      event_list = {}  -- clear the list so we only get relevant events
+      b:touch_all()    -- touch them and force dns updates
+      assert.same({
+        {
+          _event = 'afterHostUpdate',
+          host = 'konghq.com:8000',
+          nodeWeight = 100,
+          {
+            address = '1.1.1.1:3',
+            available = true,
+            disabled = false,
+            weight = 6,
+          }, {
+            address = '2.2.2.2:5',
+            available = true,
+            disabled = true,   -- marked as disabled!
+            weight = 0,        -- weight reduced to 0!
+          },
+        }, {
+          _event = 'onRemoveAddress',
+          address = '2.2.2.2:5',
+          available = true,
+          disabled = true,   -- marked as disabled!
+          weight = 0,        -- weight reduced to 0!
+        } ,
+      }, event_list)
+    end)
+
+
+    it("when adding a DNS record entry", function()
+      b:addHost("konghq.com", 8000, 100)
+      dnsExpire(record)  -- expire initial record
+      record = dnsSRV({  -- insert a new record, 1 new weight
+        { name = "konghq.com", target = "1.1.1.1", port = 3, weight = 6 },
+        { name = "konghq.com", target = "2.2.2.2", port = 5, weight = 7 },
+        { name = "konghq.com", target = "8.8.8.8", port = 9, weight = 10 },
+      })
+      event_list = {}  -- clear the list so we only get relevant events
+      b:touch_all()    -- touch them and force dns updates
+      assert.same({
+        {
+          _event = 'onAddAddress',
+          address = '8.8.8.8:9',
+          available = true,
+          disabled = false,
+          weight = 10,
+        }, {
+          _event = 'afterHostUpdate',
+          host = 'konghq.com:8000',
+          nodeWeight = 100,
+          {
+            address = '1.1.1.1:3',
+            available = true,
+            disabled = false,
+            weight = 6,
+          }, {
+            address = '2.2.2.2:5',
+            available = true,
+            disabled = false,
+            weight = 7,
+          }, {
+            address = '8.8.8.8:9',
+            available = true,
+            disabled = false,
+            weight = 10,
+          },
+        },
+      }, event_list)
+    end)
+
+
+    it("when changing an SRV weight", function()
+      b:addHost("konghq.com", 8000, 100)
+      dnsExpire(record)  -- expire initial record
+      record = dnsSRV({  -- insert a new record, 1 new weight
+        { name = "konghq.com", target = "1.1.1.1", port = 3, weight = 6 },
+        { name = "konghq.com", target = "2.2.2.2", port = 5, weight = 50 },
+      })
+      event_list = {}  -- clear the list so we only get relevant events
+      b:touch_all()    -- touch them and force dns updates
+      assert.same({
+        {
+          _event = 'afterHostUpdate',
+          host = 'konghq.com:8000',
+          nodeWeight = 100,
+          {
+            address = '1.1.1.1:3',
+            available = true,
+            disabled = false,
+            weight = 6,
+          }, {
+            address = '2.2.2.2:5',
+            available = true,
+            disabled = false,
+            weight = 50,            -- Updated weight!
+          },
+        },
+      }, event_list)
+    end)
+
+
+    it("when changing an non-SRV weight", function()
+      record = dnsA({
+        { name = "getkong.org", address = "1.2.3.4" },
+        { name = "getkong.org", address = "5.6.7.8" },
+      })
+      b:addHost("getkong.org", 8000, 100)
+      event_list = {}  -- clear the list so we only get relevant events
+      b:addHost("getkong.org", 8000, 5)  -- change the weights
+      assert.same({
+        {
+          _event = 'afterHostUpdate',
+          host = 'getkong.org:8000',
+          nodeWeight = 5,
+          {
+            address = '1.2.3.4:8000',
+            available = true,
+            disabled = false,
+            weight = 5,          -- weight updated to 5!
+          }, {
+            address = '5.6.7.8:8000',
+            available = true,
+            disabled = false,
+            weight = 5,          -- weight updated to 5!
+          },
+        },
+      }, event_list)
+    end)
+
+  end)
+
+end)

--- a/spec/balancer_base_spec.lua
+++ b/spec/balancer_base_spec.lua
@@ -1,13 +1,13 @@
 
-local dnscache, client, balancer_base
+local client, balancer_base
 
 
 local helpers = require "spec.test_helpers"
-local gettime = helpers.gettime
-local sleep = helpers.sleep
+--local gettime = helpers.gettime
+--local sleep = helpers.sleep
 local dnsSRV = function(...) return helpers.dnsSRV(client, ...) end
 local dnsA = function(...) return helpers.dnsA(client, ...) end
-local dnsAAAA = function(...) return helpers.dnsAAAA(client, ...) end
+--local dnsAAAA = function(...) return helpers.dnsAAAA(client, ...) end
 local dnsExpire = helpers.dnsExpire
 
 
@@ -30,7 +30,6 @@ describe("[balancer_base]", function()
         "nameserver 8.8.8.8"
       },
     })
-    dnscache = client.getcache()  -- must be after 'init' call because it is replaced
     snapshot = assert:snapshot()
   end)
 

--- a/spec/balancer_spec.lua
+++ b/spec/balancer_spec.lua
@@ -6,7 +6,7 @@ local icopy = require("pl.tablex").icopy
 ------------------------
 -- START TEST HELPERS --
 ------------------------
-local dnscache, client, balancer
+local client, balancer
 
 local helpers = require "spec.test_helpers"
 local gettime = helpers.gettime
@@ -123,7 +123,6 @@ describe("[ringbalancer]", function()
         "nameserver 8.8.8.8"
       },
     })
-    dnscache = client.getcache()  -- must be after 'init' call because it is replaced
     snapshot = assert:snapshot()
   end)
 
@@ -1549,8 +1548,6 @@ describe("[ringbalancer]", function()
           "nameserver 127.0.0.1:22000" -- make sure dns query fails
         },
       })
-      -- refetch the cache, since the 'init' call above caused it to be replaced
-      dnscache = client.getcache()
       record.expire = gettime() -1 -- expire current dns cache record
       -- run entire wheel to make sure the expired one is requested, so it can fail
       for _ = 1, b.wheelSize do b:getPeer() end
@@ -1565,8 +1562,6 @@ describe("[ringbalancer]", function()
           "nameserver 8.8.8.8"
         },
       })
-      -- refetch the cache, since the 'init' call above caused it to be replaced
-      dnscache = client.getcache()
       dnsA({
         { name = "mashape.com", address = "1.2.3.4" },
       })

--- a/spec/balancer_spec.lua
+++ b/spec/balancer_spec.lua
@@ -105,7 +105,7 @@ end
 ----------------------
 
 
-describe("Loadbalancer", function()
+describe("[ringbalancer]", function()
 
   local snapshot
 

--- a/spec/client_cache_spec.lua
+++ b/spec/client_cache_spec.lua
@@ -15,7 +15,7 @@ local dump = function(...)
   print(require("pl.pretty").write({...}))
 end
 
-describe("DNS client cache", function()
+describe("[DNS client cache]", function()
 
   local client, resolver, query_func
 

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -25,7 +25,7 @@ local dump = function(...)
 end
 -- luacheck: pop
 
-describe("DNS client", function()
+describe("[DNS client]", function()
 
   local client, resolver, query_func
 

--- a/spec/test_helpers.lua
+++ b/spec/test_helpers.lua
@@ -1,0 +1,113 @@
+-- test helper methods
+
+local _M = {}
+
+if ngx then
+  _M.gettime = ngx.now
+  _M.sleep = ngx.sleep
+else
+  local socket = require("socket")
+  _M.gettime = socket.gettime
+  _M.sleep = socket.sleep
+end
+local gettime = _M.gettime
+
+-- expires a record now
+function _M.dnsExpire(record)
+  record.expire = gettime() - 1
+end
+
+-- creates an SRV record in the cache
+function _M.dnsSRV(client, records, staleTtl)
+  local dnscache = client.getcache()
+  -- if single table, then insert into a new list
+  if not records[1] then records = { records } end
+
+  for _, record in ipairs(records) do
+    record.type = client.TYPE_SRV
+
+    -- check required input
+    assert(record.target, "target field is required for SRV record")
+    assert(record.name, "name field is required for SRV record")
+    assert(record.port, "port field is required for SRV record")
+    record.name = record.name:lower()
+
+    -- optionals, insert defaults
+    record.weight = record.weight or 10
+    record.ttl = record.ttl or 600
+    record.priority = record.priority or 20
+    record.class = record.class or 1
+  end
+  -- set timeouts
+  records.touch = gettime()
+  records.expire = gettime() + records[1].ttl
+
+  -- create key, and insert it
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+  return records
+end
+
+-- creates an A record in the cache
+function _M.dnsA(client, records, staleTtl)
+  local dnscache = client.getcache()
+  -- if single table, then insert into a new list
+  if not records[1] then records = { records } end
+
+  for _, record in ipairs(records) do
+    record.type = client.TYPE_A
+
+    -- check required input
+    assert(record.address, "address field is required for A record")
+    assert(record.name, "name field is required for A record")
+    record.name = record.name:lower()
+
+    -- optionals, insert defaults
+    record.ttl = record.ttl or 600
+    record.class = record.class or 1
+  end
+  -- set timeouts
+  records.touch = gettime()
+  records.expire = gettime() + records[1].ttl
+
+  -- create key, and insert it
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+  return records
+end
+
+-- creates an AAAA record in the cache
+function _M.dnsAAAA(client, records, staleTtl)
+  local dnscache = client.getcache()
+  -- if single table, then insert into a new list
+  if not records[1] then records = { records } end
+
+  for _, record in ipairs(records) do
+    record.type = client.TYPE_AAAA
+
+    -- check required input
+    assert(record.address, "address field is required for AAAA record")
+    assert(record.name, "name field is required for AAAA record")
+    record.name = record.name:lower()
+
+    -- optionals, insert defaults
+    record.ttl = record.ttl or 600
+    record.class = record.class or 1
+  end
+  -- set timeouts
+  records.touch = gettime()
+  records.expire = gettime() + records[1].ttl
+
+  -- create key, and insert it
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+  return records
+end
+
+return _M

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -13,25 +13,27 @@ else
   sleep = socket.sleep
 end
 
-describe("testing parsing 'hosts'", function()
+describe("[utils]", function()
 
-  it("tests parsing when the 'hosts' file does not exist", function()
-    local result, err = dnsutils.parseHosts("non/existing/file")
-    assert.is.Nil(result)
-    assert.is.string(err)
-  end)
+  describe("parsing 'hosts':", function()
 
-  it("tests parsing when the 'hosts' file is empty", function()
-    local filename = tempfilename()
-    writefile(filename, "")
-    local reverse, hosts = dnsutils.parseHosts(filename)
-    os.remove(filename)
-    assert.is.same({}, reverse)
-    assert.is.same({}, hosts)
-  end)
+    it("tests parsing when the 'hosts' file does not exist", function()
+      local result, err = dnsutils.parseHosts("non/existing/file")
+      assert.is.Nil(result)
+      assert.is.string(err)
+    end)
 
-  it("tests parsing 'hosts'", function()
-      local hostsfile = splitlines(
+    it("tests parsing when the 'hosts' file is empty", function()
+      local filename = tempfilename()
+      writefile(filename, "")
+      local reverse, hosts = dnsutils.parseHosts(filename)
+      os.remove(filename)
+      assert.is.same({}, reverse)
+      assert.is.same({}, hosts)
+    end)
+
+    it("tests parsing 'hosts'", function()
+        local hostsfile = splitlines(
 [[# The localhost entry should be in every HOSTS file and is used
 # to point back to yourself.
 
@@ -52,89 +54,89 @@ describe("testing parsing 'hosts'", function()
 
 [::1]        alsolocalhost  #support IPv6 in brackets
 ]])
-    local reverse, hosts = dnsutils.parseHosts(hostsfile)
-    assert.is.equal(hosts[1].ip, "127.0.0.1")
-    assert.is.equal(hosts[1].canonical, "localhost")
-    assert.is.Nil(hosts[1][1])  -- no aliases
-    assert.is.Nil(hosts[1][2])
-    assert.is.equal("127.0.0.1", reverse.localhost.ipv4)
-    assert.is.equal("[::1]", reverse.localhost.ipv6)
+      local reverse, hosts = dnsutils.parseHosts(hostsfile)
+      assert.is.equal(hosts[1].ip, "127.0.0.1")
+      assert.is.equal(hosts[1].canonical, "localhost")
+      assert.is.Nil(hosts[1][1])  -- no aliases
+      assert.is.Nil(hosts[1][2])
+      assert.is.equal("127.0.0.1", reverse.localhost.ipv4)
+      assert.is.equal("[::1]", reverse.localhost.ipv6)
 
-    assert.is.equal(hosts[2].ip, "[::1]")
-    assert.is.equal(hosts[2].canonical, "localhost")
+      assert.is.equal(hosts[2].ip, "[::1]")
+      assert.is.equal(hosts[2].canonical, "localhost")
 
-    assert.is.equal(hosts[3].ip, "192.168.1.2")
-    assert.is.equal(hosts[3].canonical, "test.computer.com")
-    assert.is.Nil(hosts[3][1])  -- no aliases
-    assert.is.Nil(hosts[3][2])
-    assert.is.equal("192.168.1.2", reverse["test.computer.com"].ipv4)
+      assert.is.equal(hosts[3].ip, "192.168.1.2")
+      assert.is.equal(hosts[3].canonical, "test.computer.com")
+      assert.is.Nil(hosts[3][1])  -- no aliases
+      assert.is.Nil(hosts[3][2])
+      assert.is.equal("192.168.1.2", reverse["test.computer.com"].ipv4)
 
-    assert.is.equal(hosts[4].ip, "192.168.1.3")
-    assert.is.equal(hosts[4].canonical, "ftp.computer.com")   -- converted to lowercase!
-    assert.is.equal(hosts[4][1], "alias1")
-    assert.is.equal(hosts[4][2], "alias2")
-    assert.is.Nil(hosts[4][3])
-    assert.is.equal("192.168.1.3", reverse["ftp.computer.com"].ipv4)
-    assert.is.equal("192.168.1.3", reverse["alias1"].ipv4)
-    assert.is.equal("192.168.1.3", reverse["alias2"].ipv4)
+      assert.is.equal(hosts[4].ip, "192.168.1.3")
+      assert.is.equal(hosts[4].canonical, "ftp.computer.com")   -- converted to lowercase!
+      assert.is.equal(hosts[4][1], "alias1")
+      assert.is.equal(hosts[4][2], "alias2")
+      assert.is.Nil(hosts[4][3])
+      assert.is.equal("192.168.1.3", reverse["ftp.computer.com"].ipv4)
+      assert.is.equal("192.168.1.3", reverse["alias1"].ipv4)
+      assert.is.equal("192.168.1.3", reverse["alias2"].ipv4)
 
-    assert.is.equal(hosts[5].ip, "192.168.1.4")
-    assert.is.equal(hosts[5].canonical, "smtp.computer.com")
-    assert.is.equal(hosts[5][1], "alias3")
-    assert.is.Nil(hosts[5][2])
-    assert.is.equal("192.168.1.4", reverse["smtp.computer.com"].ipv4)
-    assert.is.equal("192.168.1.4", reverse["alias3"].ipv4)
+      assert.is.equal(hosts[5].ip, "192.168.1.4")
+      assert.is.equal(hosts[5].canonical, "smtp.computer.com")
+      assert.is.equal(hosts[5][1], "alias3")
+      assert.is.Nil(hosts[5][2])
+      assert.is.equal("192.168.1.4", reverse["smtp.computer.com"].ipv4)
+      assert.is.equal("192.168.1.4", reverse["alias3"].ipv4)
 
-    assert.is.equal(hosts[6].ip, "192.168.1.5")
-    assert.is.equal(hosts[6].canonical, "smtp.computer.com")
-    assert.is.equal(hosts[6][1], "alias3")
-    assert.is.Nil(hosts[6][2])
-    assert.is.equal("192.168.1.4", reverse["smtp.computer.com"].ipv4)  -- .1.4; first one wins!
-    assert.is.equal("192.168.1.4", reverse["alias3"].ipv4)   -- .1.4; first one wins!
+      assert.is.equal(hosts[6].ip, "192.168.1.5")
+      assert.is.equal(hosts[6].canonical, "smtp.computer.com")
+      assert.is.equal(hosts[6][1], "alias3")
+      assert.is.Nil(hosts[6][2])
+      assert.is.equal("192.168.1.4", reverse["smtp.computer.com"].ipv4)  -- .1.4; first one wins!
+      assert.is.equal("192.168.1.4", reverse["alias3"].ipv4)   -- .1.4; first one wins!
 
-    assert.is.equal(hosts[10].ip, "[::1]")
-    assert.is.equal(hosts[10].canonical, "alsolocalhost")
-    assert.is.equal(hosts[10].family, "ipv6")
-    assert.is.equal("[::1]", reverse["alsolocalhost"].ipv6)
+      assert.is.equal(hosts[10].ip, "[::1]")
+      assert.is.equal(hosts[10].canonical, "alsolocalhost")
+      assert.is.equal(hosts[10].family, "ipv6")
+      assert.is.equal("[::1]", reverse["alsolocalhost"].ipv6)
+    end)
+
   end)
 
-end)
+  describe("parsing 'resolv.conf':", function()
 
-describe("testing parsing 'resolv.conf'", function()
+    -- override os.getenv to insert env variables
+    local old_getenv = os.getenv
+    local envvars  -- whatever is in this table, gets served first
+    before_each(function()
+      envvars = {}
+      os.getenv = function(name)     -- luacheck: ignore
+        return envvars[name] or old_getenv(name)
+      end
+    end)
 
-  -- override os.getenv to insert env variables
-  local old_getenv = os.getenv
-  local envvars  -- whatever is in this table, gets served first
-  before_each(function()
-    envvars = {}
-    os.getenv = function(name)     -- luacheck: ignore
-      return envvars[name] or old_getenv(name)
-    end
-  end)
+    after_each(function()
+      os.getenv = old_getenv         -- luacheck: ignore
+      envvars = nil
+    end)
 
-  after_each(function()
-    os.getenv = old_getenv         -- luacheck: ignore
-    envvars = nil
-  end)
+    it("tests parsing when the 'resolv.conf' file does not exist", function()
+      local result, err = dnsutils.parseResolvConf("non/existing/file")
+      assert.is.Nil(result)
+      assert.is.string(err)
+    end)
 
-  it("tests parsing when the 'resolv.conf' file does not exist", function()
-    local result, err = dnsutils.parseResolvConf("non/existing/file")
-    assert.is.Nil(result)
-    assert.is.string(err)
-  end)
+    it("tests parsing when the 'resolv.conf' file is empty", function()
+      local filename = tempfilename()
+      writefile(filename, "")
+      local resolv, err = dnsutils.parseResolvConf(filename)
+      os.remove(filename)
+      assert.is.same({}, resolv)
+      assert.is.Nil(err)
+    end)
 
-  it("tests parsing when the 'resolv.conf' file is empty", function()
-    local filename = tempfilename()
-    writefile(filename, "")
-    local resolv, err = dnsutils.parseResolvConf(filename)
-    os.remove(filename)
-    assert.is.same({}, resolv)
-    assert.is.Nil(err)
-  end)
-
-  it("tests parsing 'resolv.conf' with multiple comment types", function()
-    local file = splitlines(
-    [[# this is just a comment line
+    it("tests parsing 'resolv.conf' with multiple comment types", function()
+      local file = splitlines(
+[[# this is just a comment line
 # at the top of the file
 
 domain myservice.com
@@ -167,56 +169,56 @@ options single-request-reopen
 options no-tld-query
 options use-vc
 ]])
-    local resolv, err = dnsutils.parseResolvConf(file)
-    assert.is.Nil(err)
-    assert.is.equal("myservice.com", resolv.domain)
-    assert.is.same({ "8.8.8.8", "2602:306:bca8:1ac0::1", "8.8.8.8:1234" }, resolv.nameserver)
-    assert.is.same({ "list1", "list2" }, resolv.sortlist)
-    assert.is.same({ ndots = 2, timeout = 3, attempts = 4, debug = true, rotate = true,
-        ["no-check-names"] = true, inet6 = true, ["ip6-bytestring"] = true,
-        ["ip6-dotint"] = nil,  -- overridden by the next one, mutually exclusive
-        ["no-ip6-dotint"] = true, edns0 = true, ["single-request"] = true,
-        ["single-request-reopen"] = true, ["no-tld-query"] = true, ["use-vc"] = true},
-        resolv.options)
-  end)
+      local resolv, err = dnsutils.parseResolvConf(file)
+      assert.is.Nil(err)
+      assert.is.equal("myservice.com", resolv.domain)
+      assert.is.same({ "8.8.8.8", "2602:306:bca8:1ac0::1", "8.8.8.8:1234" }, resolv.nameserver)
+      assert.is.same({ "list1", "list2" }, resolv.sortlist)
+      assert.is.same({ ndots = 2, timeout = 3, attempts = 4, debug = true, rotate = true,
+          ["no-check-names"] = true, inet6 = true, ["ip6-bytestring"] = true,
+          ["ip6-dotint"] = nil,  -- overridden by the next one, mutually exclusive
+          ["no-ip6-dotint"] = true, edns0 = true, ["single-request"] = true,
+          ["single-request-reopen"] = true, ["no-tld-query"] = true, ["use-vc"] = true},
+          resolv.options)
+    end)
 
-  it("tests parsing 'resolv.conf' with mutual exclusive domain vs search", function()
-    local file = splitlines(
-    [[domain myservice.com
+    it("tests parsing 'resolv.conf' with mutual exclusive domain vs search", function()
+      local file = splitlines(
+[[domain myservice.com
 
 # search is overriding domain above
 search domaina.com domainb.com
 
 ]])
-    local resolv, err = dnsutils.parseResolvConf(file)
-    assert.is.Nil(err)
-    assert.is.Nil(resolv.domain)
-    assert.is.same({ "domaina.com", "domainb.com" }, resolv.search)
-  end)
+      local resolv, err = dnsutils.parseResolvConf(file)
+      assert.is.Nil(err)
+      assert.is.Nil(resolv.domain)
+      assert.is.same({ "domaina.com", "domainb.com" }, resolv.search)
+    end)
 
-  it("tests parsing 'resolv.conf' with max search entries MAXSEARCH", function()
-    local file = splitlines(
-    [[
+    it("tests parsing 'resolv.conf' with max search entries MAXSEARCH", function()
+      local file = splitlines(
+[[
 
 search domain1.com domain2.com domain3.com domain4.com domain5.com domain6.com domain7.com
 
 ]])
-    local resolv, err = dnsutils.parseResolvConf(file)
-    assert.is.Nil(err)
-    assert.is.Nil(resolv.domain)
-    assert.is.same({
-        "domain1.com",
-        "domain2.com",
-        "domain3.com",
-        "domain4.com",
-        "domain5.com",
-        "domain6.com",
-      }, resolv.search)
-  end)
+      local resolv, err = dnsutils.parseResolvConf(file)
+      assert.is.Nil(err)
+      assert.is.Nil(resolv.domain)
+      assert.is.same({
+          "domain1.com",
+          "domain2.com",
+          "domain3.com",
+          "domain4.com",
+          "domain5.com",
+          "domain6.com",
+        }, resolv.search)
+    end)
 
-  it("tests parsing 'resolv.conf' with environment variables", function()
-    local file = splitlines(
-    [[# this is just a comment line
+    it("tests parsing 'resolv.conf' with environment variables", function()
+      local file = splitlines(
+[[# this is just a comment line
 domain myservice.com
 
 nameserver 8.8.8.8
@@ -224,22 +226,22 @@ nameserver 8.8.4.4 ; and a comment here
 
 options ndots:1
 ]])
-    local resolv, err = dnsutils.parseResolvConf(file)
-    assert.is.Nil(err)
+      local resolv, err = dnsutils.parseResolvConf(file)
+      assert.is.Nil(err)
 
-    envvars.LOCALDOMAIN = "domaina.com domainb.com"
-    envvars.RES_OPTIONS = "ndots:2 debug"
-    resolv = dnsutils.applyEnv(resolv)
+      envvars.LOCALDOMAIN = "domaina.com domainb.com"
+      envvars.RES_OPTIONS = "ndots:2 debug"
+      resolv = dnsutils.applyEnv(resolv)
 
-    assert.is.Nil(resolv.domain)  -- must be nil, mutually exclusive
-    assert.is.same({ "domaina.com", "domainb.com" }, resolv.search)
+      assert.is.Nil(resolv.domain)  -- must be nil, mutually exclusive
+      assert.is.same({ "domaina.com", "domainb.com" }, resolv.search)
 
-    assert.is.same({ ndots = 2, debug = true }, resolv.options)
-  end)
+      assert.is.same({ ndots = 2, debug = true }, resolv.options)
+    end)
 
-  it("tests parsing 'resolv.conf' with non-existing environment variables", function()
-    local file = splitlines(
-    [[# this is just a comment line
+    it("tests parsing 'resolv.conf' with non-existing environment variables", function()
+      local file = splitlines(
+[[# this is just a comment line
 domain myservice.com
 
 nameserver 8.8.8.8
@@ -247,119 +249,121 @@ nameserver 8.8.4.4 ; and a comment here
 
 options ndots:2
 ]])
-    local resolv, err = dnsutils.parseResolvConf(file)
-    assert.is.Nil(err)
+      local resolv, err = dnsutils.parseResolvConf(file)
+      assert.is.Nil(err)
 
-    envvars.LOCALDOMAIN = ""
-    envvars.RES_OPTIONS = ""
-    resolv = dnsutils.applyEnv(resolv)
+      envvars.LOCALDOMAIN = ""
+      envvars.RES_OPTIONS = ""
+      resolv = dnsutils.applyEnv(resolv)
 
-    assert.is.equals("myservice.com", resolv.domain)  -- must be nil, mutually exclusive
+      assert.is.equals("myservice.com", resolv.domain)  -- must be nil, mutually exclusive
 
-    assert.is.same({ ndots = 2 }, resolv.options)
+      assert.is.same({ ndots = 2 }, resolv.options)
+    end)
+
+    it("tests pass-through error handling of 'applyEnv'", function()
+      local fname = "non/existing/file"
+      local r1, e1 = dnsutils.parseResolvConf(fname)
+      local r2, e2 = dnsutils.applyEnv(dnsutils.parseResolvConf(fname))
+      assert.are.same(r1, r2)
+      assert.are.same(e1, e2)
+    end)
+
   end)
 
-  it("tests pass-through error handling of 'applyEnv'", function()
-    local fname = "non/existing/file"
-    local r1, e1 = dnsutils.parseResolvConf(fname)
-    local r2, e2 = dnsutils.applyEnv(dnsutils.parseResolvConf(fname))
-    assert.are.same(r1, r2)
-    assert.are.same(e1, e2)
-  end)
+  describe("cached versions", function()
 
-end)
+    local utils = require("pl.utils")
+    local oldreadlines = utils.readlines
 
-describe("cached versions", function()
-
-  local utils = require("pl.utils")
-  local oldreadlines = utils.readlines
-
-  before_each(function()
-    utils.readlines = function(name)
-      if name:match("hosts") then
-        return {  -- hosts file
-            "127.0.0.1 localhost",
-            "192.168.1.2 test.computer.com",
-            "192.168.1.3 ftp.computer.com alias1 alias2",
-          }
-      else
-        return {  -- resolv.conf file
-            "domain myservice.com",
-            "nameserver 8.8.8.8 ",
-          }
+    before_each(function()
+      utils.readlines = function(name)
+        if name:match("hosts") then
+          return {  -- hosts file
+              "127.0.0.1 localhost",
+              "192.168.1.2 test.computer.com",
+              "192.168.1.3 ftp.computer.com alias1 alias2",
+            }
+        else
+          return {  -- resolv.conf file
+              "domain myservice.com",
+              "nameserver 8.8.8.8 ",
+            }
+        end
       end
-    end
+    end)
+
+    after_each(function()
+      utils.readlines = oldreadlines
+    end)
+
+    it("tests caching the hosts file", function()
+      local val1r, val1 = dnsutils.getHosts()
+      local val2r, val2 = dnsutils.getHosts()
+      assert.Not.equal(val1, val2) -- no ttl specified, so distinct tables
+      assert.Not.equal(val1r, val2r) -- no ttl specified, so distinct tables
+
+      val1r, val1 = dnsutils.getHosts(1)
+      val2r, val2 = dnsutils.getHosts()
+      assert.are.equal(val1, val2)   -- ttl specified, so same tables
+      assert.are.equal(val1r, val2r) -- ttl specified, so same tables
+
+      -- wait for cache to expire
+      sleep(2)
+
+      val2r, val2 = dnsutils.getHosts()
+      assert.Not.equal(val1, val2) -- ttl timed out, so distinct tables
+      assert.Not.equal(val1r, val2r) -- ttl timed out, so distinct tables
+    end)
+
+    it("tests caching the resolv.conf file & variables", function()
+      local val1 = dnsutils.getResolv()
+      local val2 = dnsutils.getResolv()
+      assert.Not.equal(val1, val2) -- no ttl specified, so distinct tables
+
+      val1 = dnsutils.getResolv(1)
+      val2 = dnsutils.getResolv()
+      assert.are.equal(val1, val2)   -- ttl specified, so same tables
+
+      -- wait for cache to expire
+      sleep(2)
+
+      val2 = dnsutils.getResolv()
+      assert.Not.equal(val1, val2)   -- ttl timed out, so distinct tables
+    end)
+
   end)
 
-  after_each(function()
-    utils.readlines = oldreadlines
+  describe("hostnameType", function()
+    -- no check on "name" type as anything not ipv4 and not ipv6 will be labelled as 'name' anyway
+    it("checks valid IPv4 address types", function()
+      assert.are.same("ipv4", dnsutils.hostnameType("123.123.123.123"))
+      assert.are.same("ipv4", dnsutils.hostnameType("1.2.3.4"))
+    end)
+    it("checks valid IPv6 address types", function()
+      assert.are.same("ipv6", dnsutils.hostnameType("::1"))
+      assert.are.same("ipv6", dnsutils.hostnameType("2345::6789"))
+      assert.are.same("ipv6", dnsutils.hostnameType("0001:0001:0001:0001:0001:0001:0001:0001"))
+    end)
   end)
 
-  it("tests caching the hosts file", function()
-    local val1r, val1 = dnsutils.getHosts()
-    local val2r, val2 = dnsutils.getHosts()
-    assert.Not.equal(val1, val2) -- no ttl specified, so distinct tables
-    assert.Not.equal(val1r, val2r) -- no ttl specified, so distinct tables
-
-    val1r, val1 = dnsutils.getHosts(1)
-    val2r, val2 = dnsutils.getHosts()
-    assert.are.equal(val1, val2)   -- ttl specified, so same tables
-    assert.are.equal(val1r, val2r) -- ttl specified, so same tables
-
-    -- wait for cache to expire
-    sleep(2)
-
-    val2r, val2 = dnsutils.getHosts()
-    assert.Not.equal(val1, val2) -- ttl timed out, so distinct tables
-    assert.Not.equal(val1r, val2r) -- ttl timed out, so distinct tables
+  describe("parseHostname", function()
+    it("parses valid IPv4 address types", function()
+      assert.are.same({"123.123.123.123", nil, "ipv4"}, {dnsutils.parseHostname("123.123.123.123")})
+      assert.are.same({"1.2.3.4", 567, "ipv4"}, {dnsutils.parseHostname("1.2.3.4:567")})
+    end)
+    it("parses valid IPv6 address types", function()
+      assert.are.same({"[::1]", nil, "ipv6"}, {dnsutils.parseHostname("::1")})
+      assert.are.same({"[::1]", nil, "ipv6"}, {dnsutils.parseHostname("[::1]")})
+      assert.are.same({"[::1]", 123, "ipv6"}, {dnsutils.parseHostname("[::1]:123")})
+      assert.are.same({"[2345::6789]", nil, "ipv6"}, {dnsutils.parseHostname("2345::6789")})
+      assert.are.same({"[2345::6789]", nil, "ipv6"}, {dnsutils.parseHostname("[2345::6789]")})
+      assert.are.same({"[2345::6789]", 321, "ipv6"}, {dnsutils.parseHostname("[2345::6789]:321")})
+    end)
+    it("parses valid name address types", function()
+      assert.are.same({"somename", nil, "name"}, {dnsutils.parseHostname("somename")})
+      assert.are.same({"somename", 123, "name"}, {dnsutils.parseHostname("somename:123")})
+    end)
   end)
 
-  it("tests caching the resolv.conf file & variables", function()
-    local val1 = dnsutils.getResolv()
-    local val2 = dnsutils.getResolv()
-    assert.Not.equal(val1, val2) -- no ttl specified, so distinct tables
-
-    val1 = dnsutils.getResolv(1)
-    val2 = dnsutils.getResolv()
-    assert.are.equal(val1, val2)   -- ttl specified, so same tables
-
-    -- wait for cache to expire
-    sleep(2)
-
-    val2 = dnsutils.getResolv()
-    assert.Not.equal(val1, val2)   -- ttl timed out, so distinct tables
-  end)
-
-end)
-
-describe("hostnameType", function()
-  -- no check on "name" type as anything not ipv4 and not ipv6 will be labelled as 'name' anyway
-  it("checks valid IPv4 address types", function()
-    assert.are.same("ipv4", dnsutils.hostnameType("123.123.123.123"))
-    assert.are.same("ipv4", dnsutils.hostnameType("1.2.3.4"))
-  end)
-  it("checks valid IPv6 address types", function()
-    assert.are.same("ipv6", dnsutils.hostnameType("::1"))
-    assert.are.same("ipv6", dnsutils.hostnameType("2345::6789"))
-    assert.are.same("ipv6", dnsutils.hostnameType("0001:0001:0001:0001:0001:0001:0001:0001"))
-  end)
-end)
-
-describe("parseHostname", function()
-  it("parses valid IPv4 address types", function()
-    assert.are.same({"123.123.123.123", nil, "ipv4"}, {dnsutils.parseHostname("123.123.123.123")})
-    assert.are.same({"1.2.3.4", 567, "ipv4"}, {dnsutils.parseHostname("1.2.3.4:567")})
-  end)
-  it("parses valid IPv6 address types", function()
-    assert.are.same({"[::1]", nil, "ipv6"}, {dnsutils.parseHostname("::1")})
-    assert.are.same({"[::1]", nil, "ipv6"}, {dnsutils.parseHostname("[::1]")})
-    assert.are.same({"[::1]", 123, "ipv6"}, {dnsutils.parseHostname("[::1]:123")})
-    assert.are.same({"[2345::6789]", nil, "ipv6"}, {dnsutils.parseHostname("2345::6789")})
-    assert.are.same({"[2345::6789]", nil, "ipv6"}, {dnsutils.parseHostname("[2345::6789]")})
-    assert.are.same({"[2345::6789]", 321, "ipv6"}, {dnsutils.parseHostname("[2345::6789]:321")})
-  end)
-  it("parses valid name address types", function()
-    assert.are.same({"somename", nil, "name"}, {dnsutils.parseHostname("somename")})
-    assert.are.same({"somename", 123, "name"}, {dnsutils.parseHostname("somename:123")})
-  end)
 end)

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -1,9 +1,12 @@
 --------------------------------------------------------------------------
 -- Ring-balancer.
 --
+-- This balancer implements a consistent-hashing algorithm as well as a
+-- weighted-round-robin.
+--
 -- This loadbalancer is designed for consistent hashing approaches and
 -- to retain consistency on a maximum level while dealing with dynamic
--- changes like adding/removing hosts/targets.
+-- changes like adding/removing hosts/targets (ketama principle).
 --
 -- Due to its deterministic way of operating it is also capable of running
 -- identical balancers (identical consistent rings) on multiple servers/workers
@@ -14,127 +17,64 @@
 -- Adding/deleting hosts, etc (as long as done in the same order) is always
 -- deterministic.
 --
--- Updating the dns records is passive, meaning that when `getPeer` accesses a
--- target, only then the check is done whether the record is stale, and if so
--- it is updated. The one exception is the failed dns queries (because they
--- have no indices assigned, and hence will never be hit by `getPeer`), which will
--- be actively refreshed using a timer.
---
 -- Whenever dns resolution fails for a hostname, the host will relinguish all
 -- the indices it owns, and they will be reassigned to other targets.
 -- Periodically the query for the hostname will be retried, and if it succeeds
 -- it will get (different) indices reassigned to it.
 --
--- __Housekeeping__; the ring-balancer does some house keeping and may insert
--- some extra fields in dns records. Those fields will have an `__` prefix
--- (double underscores).
+-- When using `setPeerStatus` to mark a peer as unavailable, the slots it owns will
+-- not be reassigned. So after a recovery, hashing will be restored.
+--
+--
+-- __NOTE:__ This documentation only described the altered user methods/properties
+-- from a see the `user properties` from the `balancer_base` for a complete overview.
 --
 -- @author Thijs Schreijer
 -- @copyright 2016-2018 Kong Inc. All rights reserved.
 -- @license Apache 2.0
 
 
-local DEFAULT_WEIGHT = 10   -- default weight for a host, if not provided
-local DEFAULT_PORT = 80     -- Default port to use (A and AAAA only) when not provided
-local TTL_0_RETRY = 60      -- Maximum life-time for hosts added with ttl=0, requery after it expires
-local REQUERY_INTERVAL = 30 -- Interval for requerying failed dns queries
-local ERR_INDEX_REASSIGNED = "Cannot get peer, current index got reassigned to another address"
-local ERR_ADDRESS_UNAVAILABLE = "Address is marked as unavailable"
-local ERR_NO_PEERS_AVAILABLE = "No peers are available"
-
-local bit = require "bit"
-local dns = require "resty.dns.client"
-local utils = require "resty.dns.utils"
+local balancer_base = require "resty.dns.balancer_base"
 local lrandom = require "random"
+local bit = require "bit"
+local math_floor = math.floor
+local string_sub = string.sub
+local table_sort = table.sort
+local ngx_md5 = ngx.md5_bin
+local bxor = bit.bxor
+local ngx_log = ngx.log
+local ngx_DEBUG = ngx.DEBUG
+local ngx_WARN = ngx.WARN
+
 local empty = setmetatable({},
   {__newindex = function() error("The 'empty' table is read-only") end})
 
-local time = ngx.now
-local table_sort = table.sort
-local table_remove = table.remove
-local table_concat = table.concat
-local math_floor = math.floor
-local string_sub = string.sub
-local string_format = string.format
-local ngx_md5 = ngx.md5_bin
-local timer_at = ngx.timer.at
-local bxor = bit.bxor
-local ngx_log = ngx.log
-local ngx_ERR = ngx.ERR
-local ngx_DEBUG = ngx.DEBUG
-local ngx_WARN = ngx.WARN
-local balancer_id_counter = 0
+local new_tab
+do
+  local ok
+  ok, new_tab = pcall(require, "table.new")
+  if not ok then
+      new_tab = function() return {} end
+  end
+end
+
 
 local _M = {}
-
-local ok, new_tab = pcall(require, "table.new")
-if not ok then
-    new_tab = function() return {} end
-end
-
---------------------------------------------------------
--- GC'able timer implementation with 'self'
---------------------------------------------------------
-local timer_registry = setmetatable({},{ __mode = "v" })
-local timer_id = 0
-
-local timer_callback = function(premature, cb, id, ...)
-  local self = timer_registry[id]
-  if not self then return end  -- GC'ed, nothing more to do
-  timer_registry[id] = nil
-  return cb(premature, self, ...)
-end
-
-local gctimer = function(t, cb, self, ...)
-  assert(type(cb) == "function", "expected arg #2 to be a function")
-  assert(type(self) == "table", "expected arg #3 to be a table")
-  timer_id = timer_id + 1
-  timer_registry[timer_id] = self
-  -- if in the call below we'd be passing `self` instead of the scalar `timer_id`, it
-  -- would prevent the whole `self` object from being garbage collected because
-  -- it is anchored on the timer.
-  return timer_at(t, timer_callback, cb, timer_id, ...)
-end
+local ring_balancer = {}
 
 
 -- ===========================================================================
 -- address object.
--- Manages an ip address. It links to a `host`, and is associated with a number
--- of indices of the balancer-wheel managed by the `balancer`.
 -- ===========================================================================
-local objAddr = {}
 
--- Returns the peer info.
--- @return ip-address, port and hostname of the target, or nil+err if unavailable
--- or lookup error
-function objAddr:getPeer(cacheOnly)
-  if not self.available then
-    return nil, ERR_ADDRESS_UNAVAILABLE
-  end
-
-  if self.ipType == "name" then
-    -- SRV type record with a named target
-    local ip, port, try_list = dns.toip(self.ip, self.port, cacheOnly)
-    if not ip then
-      port = tostring(port) .. ". Tried: " .. tostring(try_list)
-    end
-    -- which is the proper name to return in this case?
-    -- `self.host.hostname`? or the named SRV entry: `self.ip`?
-    -- use our own hostname, as it might be used to mark this address
-    -- as unhealthy, so we must be able to find it
-    return ip, port, self.host.hostname
-  else
-    -- just an IP address
-    return self.ip, self.port, self.host.hostname
-  end
-end
+local ring_address = {}
 
 -- Adds a list of indices to the address. The indices added to the address will
 -- be removed from the provided `availableIndicesList`.
 -- @param availableIndicesList a list of wheel-indices available for adding
 -- @param count the number of indices to take from the list provided, defaults to ALL if omitted
 -- @return the address object
-function objAddr:addIndices(availableIndicesList, count)
+function ring_address:addIndices(availableIndicesList, count)
   count = count or #availableIndicesList
   if count > 0 then
     local myWheelIndices = self.indices
@@ -167,7 +107,7 @@ end
 -- @param availableIndicesList The list to add the dropped indices to
 -- @param count (optional) The number of indices to drop, defaults to ALL if omitted
 -- @return availableIndicesList with added to it the indices removed from this address
-function objAddr:dropIndices(availableIndicesList, count)
+function ring_address:dropIndices(availableIndicesList, count)
   local myWheelIndices = self.indices
   local size = #myWheelIndices
   count = count or size
@@ -199,482 +139,57 @@ function objAddr:dropIndices(availableIndicesList, count)
   return availableIndicesList
 end
 
--- disables an address object from the balancer.
--- It will set its weight to 0, so the next indices-recalculation
--- can delete the address by calling `delete`.
--- @see delete
-function objAddr:disable()
-  ngx_log(ngx_DEBUG, self.log_prefix, "disabling address: ", self.ip, ":", self.port,
-          " (host ", (self.host or empty).hostname, ")")
 
-  -- weight to 0; force dropping all indices assigned, before actually removing
-  self.host:addWeight(-self.weight)
-  self.weight = 0
-  self.disabled = true
-end
-
--- cleans up an address object.
--- The address must have been disabled before.
--- @see disable
-function objAddr:delete()
-  ngx_log(ngx_DEBUG, self.log_prefix, "deleting address: ", self.ip, ":", self.port,
-          " (host ", (self.host or empty).hostname, ")")
-
+function ring_address:delete()
   assert(#self.indices == 0, "Cannot delete address while it owns indices")
-  self.host.balancer:callback("removed", self.ip,
-                              self.port, self.host.hostname)
-  self.host = nil
+  return self.super.delete(self)
 end
 
--- changes the weight of an address.
--- requires redistributing indices afterwards
-function objAddr:change(newWeight)
-  ngx_log(ngx_DEBUG, self.log_prefix, "changing address weight: ", self.ip, ":", self.port,
-          "(host ", (self.host or empty).hostname, ") ",
-          self.weight, " -> ", newWeight)
 
-  self.host:addWeight(newWeight - self.weight)
-  self.weight = newWeight
-end
+function ring_balancer:newAddress(addr)
+  addr = self.super.newAddress(self, addr)
 
--- Set the availability of the address.
-function objAddr:setState(available)
-  self.available = not not available -- force to boolean
-end
+  -- inject additional properties
+  addr.indices = {}     -- the indices of the wheel assigned to this address
+  addr.indicesMax = 0   -- max size reached for 'indices' table
 
--- creates a new address object.
--- @param ip the upstream ip address or target name
--- @param port the upstream port number
--- @param weight the relative weight for the balancer algorithm
--- @param host the host object the address belongs to
--- @return new address object
-local newAddress = function(ip, port, weight, host)
-  local addr = {
-    -- properties
-    ip = ip,              -- might be a name (for SRV records)
-    ipType = utils.hostnameType(ip),  -- 'ipv4', 'ipv6' or 'name'
-    port = port,
-    weight = weight,
-    available = true,     -- is this target available?
-    host = host,          -- the host this address belongs to
-    indices = {},         -- the indices of the wheel assigned to this address
-    indicesMax = 0,       -- max size reached for 'indices' table
-    disabled = false,     -- has this record been disabled? (before deleting)
-    log_prefix = host.log_prefix
-  }
-  for name, method in pairs(objAddr) do addr[name] = method end
+  -- inject overridden methods
+  for name, method in pairs(ring_address) do
+    addr[name] = method
+  end
 
-  host:addWeight(weight)
-
-  ngx_log(ngx_DEBUG, host.log_prefix, "new address for host '", host.hostname,
-          "' created: ", ip, ":", port, " (weight ", weight,")")
-  host.balancer:callback("added", ip, port, host.hostname)
   return addr
 end
 
 
 -- ===========================================================================
 -- Host object.
--- Manages a single hostname, with DNS resolution and expanding into
--- multiple upstream IPs.
 -- ===========================================================================
-local objHost = {}
 
--- define sort order for DNS query results
-local sortQuery = function(a,b) return a.__balancerSortKey < b.__balancerSortKey end
-local sorts = {
-  [dns.TYPE_A] = function(result)
-    local sorted = {}
-    -- build table with keys
-    for i, v in ipairs(result) do
-      sorted[i] = v
-      v.__balancerSortKey = v.address
-    end
-    -- sort by the keys
-    table_sort(sorted, sortQuery)
-    -- reverse index
-    for i, v in ipairs(sorted) do sorted[v.__balancerSortKey] = i end
-    return sorted
-  end,
-  [dns.TYPE_SRV] = function(result)
-    local sorted = {}
-    -- build table with keys
-    for i, v in ipairs(result) do
-      sorted[i] = v
-      v.__balancerSortKey = string_format("%06d:%s:%s:%s", v.priority, v.target, v.port, v.weight)
-    end
-    -- sort by the keys
-    table_sort(sorted, sortQuery)
-    -- reverse index
-    for i, v in ipairs(sorted) do sorted[v.__balancerSortKey] = i end
-    return sorted
-  end,
-}
-sorts[dns.TYPE_AAAA] = sorts[dns.TYPE_A] -- A and AAAA use the same sorting order
-sorts = setmetatable(sorts,{
-    -- all record types not mentioned above are unsupported, throw error
-    __index = function(self, key)
-      error("Unknown/unsupported DNS record type; "..tostring(key))
-    end,
-  })
+--local ring_host = {}
 
--- Queries the DNS for this hostname. Updates the underlying address objects.
--- This method always succeeds, but it might leave the balancer in a 0-weight
--- state if none of the hosts resolves, and hence none of the indices are allocated
--- to 'addresss' objects.
--- @return `true`, always succeeds
-function objHost:queryDns(cacheOnly)
+--function ring_balancer:newHost(host)
+--  host = self.super.newHost(self, host)
 
-  ngx_log(ngx_DEBUG, self.log_prefix, "querying dns for ", self.hostname)
+--  -- inject additional properties
 
-  -- first thing we do is the dns query, this is the only place we possibly
-  -- yield (cosockets in the dns lib). So once that is done, we're 'atomic'
-  -- again, and we shouldn't have any nasty race conditions
-  local dns = self.balancer.dns
-  local newQuery, err, try_list = dns.resolve(self.hostname, nil, cacheOnly)
+--  -- inject overridden methods
+--  for name, method in pairs(ring_host) do
+--    host[name] = method
+--  end
 
-  local oldQuery = self.lastQuery or {}
-  local oldSorted = self.lastSorted or {}
-
-  if err then
-    ngx_log(ngx_WARN, self.log_prefix, "querying dns for ", self.hostname,
-            " failed: ", err , ". Tried ", tostring(try_list))
-
-    -- TODO: so we got an error, what to do? multiple options;
-    -- 1) disable the current information (dropping all indices for this host)
-    -- 2) keep running on existing info, until some timeout, and then do 1.
-    -- For now option 1.
-    newQuery = {
-      __errorQueryFlag = true  --flag to mark the record as a failed lookup
-    }
-    self.balancer:startRequery()
-  end
-
-  -- we're using the dns' own cache to check for changes.
-  -- if our previous result is the same table as the current result, then nothing changed
-  if oldQuery == newQuery then
-    ngx_log(ngx_DEBUG, self.log_prefix, "no dns changes detected for ", self.hostname)
-
-    return true    -- exit, nothing changed
-  end
-
-  -- To detect ttl = 0 we validate both the old and new record. This is done to ensure
-  -- we do not hit the edgecase of https://github.com/Kong/lua-resty-dns-client/issues/51
-  -- So if we get a ttl=0 twice in a row (the old one, and the new one), we update it. And
-  -- if the very first request ever reports ttl=0 (we assume we're not hitting the edgecase
-  -- in that case)
-  if (newQuery[1] or empty).ttl == 0 and ((oldQuery[1] or empty).ttl or 0) == 0 then
-    -- ttl = 0 means we need to lookup on every request.
-    -- To enable lookup on each request we 'abuse' a virtual SRV record. We set the ttl
-    -- to `ttl0Interval` seconds, and set the `target` field to the hostname that needs
-    -- resolving. Now `getPeer` will resolve on each request if the target is not an IP address,
-    -- and after `ttl0Interval` seconds we'll retry to see whether the ttl has changed to non-0.
-    -- Note: if the original record is an SRV we cannot use the dns provided weights,
-    -- because we can/are not going to possibly change weights on each request
-    -- so we fix them at the `nodeWeight` property, as with A and AAAA records.
-    if oldQuery.__ttl0Flag then
-      -- still ttl 0 so nothing changed
-      ngx_log(ngx_DEBUG, self.log_prefix, "no dns changes detected for ",
-              self.hostname, ", still using ttl=0")
-      return true
-    end
-    ngx_log(ngx_DEBUG, self.log_prefix, "ttl=0 detected for ",
-            self.hostname)
-    newQuery = {
-        {
-          type = dns.TYPE_SRV,
-          target = self.hostname,
-          name = self.hostname,
-          port = self.port,
-          weight = self.nodeWeight,
-          priority = 1,
-          ttl = self.balancer.ttl0Interval,
-        },
-        expire = time() + self.balancer.ttl0Interval,
-        touched = time(),
-        __ttl0Flag = true,        -- flag marking this record as a fake SRV one
-      }
-  end
-
-  -- a new dns record, was returned, but contents could still be the same, so check for changes
-  -- sort table in unique order
-  local rtype = (newQuery[1] or empty).type
-  if not rtype then
-    -- we got an empty query table, so assume A record, because it's empty
-    -- all existing addresses will be removed
-    ngx_log(ngx_DEBUG, self.log_prefix, "blank dns record for ",
-              self.hostname, ", assuming A-record")
-    rtype = dns.TYPE_A
-  end
-  local newSorted = sorts[rtype](newQuery)
-  local dirty
-
-  if rtype ~= (oldSorted[1] or empty).type then
-    -- DNS recordtype changed; recycle everything
-    ngx_log(ngx_DEBUG, self.log_prefix, "dns record type changed for ",
-            self.hostname, ", ", (oldSorted[1] or empty).type, " -> ",rtype)
-    for i = #oldSorted, 1, -1 do  -- reverse order because we're deleting items
-      self:disableAddress(oldSorted[i])
-    end
-    for _, entry in ipairs(newSorted) do -- use sorted table for deterministic order
-      self:addAddress(entry)
-    end
-    dirty = true
-  else
-    -- new record, but the same type
-    local topPriority = (newSorted[1] or empty).priority -- nil for non-SRV records
-    local done = {}
-    local dCount = 0
-    for _, newEntry in ipairs(newSorted) do
-      if newEntry.priority ~= topPriority then break end -- exit when priority changes, as SRV only uses top priority
-
-      local key = newEntry.__balancerSortKey
-      local oldEntry = oldSorted[oldSorted[key] or "__key_not_found__"]
-      if not oldEntry then
-        -- it's a new entry
-        ngx_log(ngx_DEBUG, self.log_prefix, "new dns record entry for ",
-                self.hostname, ": ", (newEntry.target or newEntry.address),
-                ":", newEntry.port) -- port = nil for A or AAAA records
-        self:addAddress(newEntry)
-        dirty = true
-      else
-        -- it already existed (same ip, port and weight)
-        ngx_log(ngx_DEBUG, self.log_prefix, "unchanged dns record entry for ",
-                self.hostname, ": ", (newEntry.target or newEntry.address),
-                ":", newEntry.port) -- port = nil for A or AAAA records
-        done[key] = true
-        dCount = dCount + 1
-      end
-    end
-    if dCount ~= #oldSorted then
-      -- not all existing entries were handled, remove the ones that are not in the
-      -- new query result
-      for _, entry in ipairs(oldSorted) do
-        if not done[entry.__balancerSortKey] then
-          ngx_log(ngx_DEBUG, self.log_prefix, "removed dns record entry for ",
-                  self.hostname, ": ", (entry.target or entry.address),
-                  ":", entry.port) -- port = nil for A or AAAA records
-          self:disableAddress(entry)
-        end
-      end
-      dirty = true
-    end
-  end
-
-  self.lastQuery = newQuery
-  self.lastSorted = newSorted
-
-  if dirty then -- changes imply we need to redistribute indices
-    ngx_log(ngx_DEBUG, self.log_prefix, "updating wheel based on dns changes for ",
-            self.hostname)
-
-    -- recalculate to move indices of disabled addresses
-    self.balancer:redistributeIndices()
-    -- delete addresses previously disabled
-    self:deleteAddresses()
-  end
-
-  ngx_log(ngx_DEBUG, self.log_prefix, "querying dns and updating for ", self.hostname, " completed")
-  return true
-end
-
--- Changes the host overall weight. It will also update the parent balancer object.
--- To be called whenever an address is added/removed/changed
-function objHost:addWeight(delta)
-  self.weight = self.weight + delta
-  self.balancer:addWeight(delta)
-end
-
--- Updates the host nodeWeight.
--- @return `true` if something changed and indices must be redistributed
-function objHost:change(newWeight)
-  local dirty = false
-  self.nodeWeight = newWeight
-  local lastQuery = self.lastQuery or {}
-  if #lastQuery > 0 then
-    if lastQuery[1].type == dns.TYPE_SRV and not lastQuery.__ttl0Flag then
-      -- this is an SRV record (and not a fake ttl=0 one), which
-      -- carries its own weight setting, so nothing to update
-      ngx_log(ngx_DEBUG, self.log_prefix, "ignoring weight change for ", self.hostname,
-              " as SRV records carry their own weight")
-    else
-      -- so here we have A, AAAA, or a fake SRV, which uses the `nodeWeight` property
-      -- go update all our addresses
-      for _, addr in ipairs(self.addresses) do
-        addr:change(newWeight)
-      end
-      dirty = true
-    end
-  end
-  return dirty
-end
-
--- Adds an `address` object to the `host`.
--- @param entry (table) DNS entry
-function objHost:addAddress(entry)
-  local weight = entry.weight  -- nil for anything else than SRV
-  if weight == 0 then
-    -- Special case: SRV with weight = 0 should be included, but with
-    -- the lowest possible probability of being hit. So we force it to
-    -- weight 1.
-    weight = 1
-  end
-  local addresses = self.addresses
-  addresses[#addresses+1] = newAddress(
-    entry.address or entry.target,
-    (entry.port ~= 0 and entry.port) or self.port,
-    weight or self.nodeWeight,
-    self
-  )
-end
-
--- Looks up and disables an `address` object from the `host`.
--- @param entry (table) DNS entry
--- @return address object that was disabled
-function objHost:disableAddress(entry)
-  -- first lookup address object
-  for _, addr in ipairs(self.addresses) do
-    if (addr.ip == (entry.address or entry.target)) and
-        addr.port == (entry.port or self.port) and
-        not addr.disabled then
-      -- found it
-      addr:disable()
-      return addr
-    end
-  end
-end
-
--- Looks up and deletes previously disabled `address` objects from the `host`.
--- @return `true`
-function objHost:deleteAddresses()
-  for i = #self.addresses, 1, -1 do -- deleting entries, hence reverse traversal
-    if self.addresses[i].disabled then
-      self.addresses[i]:delete()
-      table_remove(self.addresses, i)
-    end
-  end
-
-  return true
-end
-
--- disables a host, by setting all adressess to 0
--- Host can only be deleted after recalculating the indices!
--- @return true
-function objHost:disable()
-  -- set weights to 0
-  for _, addr in ipairs(self.addresses) do
-    addr:disable()
-  end
-
-  return true
-end
-
--- Cleans up a host. Only when its weight is 0.
--- Should only be called AFTER recalculating indices
--- @return true or throws an error if weight is non-0
-function objHost:delete()
-  assert(self.weight == 0, "Cannot delete a host with a non-0 weight")
-
-  for i = #self.addresses, 1, -1 do  -- reverse traversal as we're deleting
-    self.addresses[i]:delete()
-  end
-
-  self.balancer = nil
-end
-
--- Gets address and port number from a specific address owned by the host.
--- The address/index MUST be owned by the host. Call balancer:getPeer, never this one.
--- access: balancer:getPeer->address->host->returns addr+port
-function objHost:getPeer(cacheOnly, address)
-
-  if (self.lastQuery.expire or 0) < time() and not cacheOnly then
-    -- ttl expired, so must renew
-    self:queryDns(cacheOnly)
-
-    if (address or empty).host ~= self then
-      -- our index has been reallocated to another host/address, so recurse to start over
-      ngx_log(ngx_DEBUG, self.log_prefix, "index previously assigned to ", self.hostname,
-              " was reassigned to another due to a dns update")
-      return nil, ERR_INDEX_REASSIGNED
-    end
-  end
-
-  return address:getPeer(cacheOnly)
-end
-
--- creates a new host object.
--- A host refers to a host name. So a host can have multiple addresses.
--- @param hostname the upstream hostname (as used in dns queries)
--- @param port the upstream port number for A and AAAA dns records. For SRV records the reported port by the DNS server will be used.
--- @param weight the relative weight for the balancer algorithm to assign to each A or AAAA dns record. For SRV records the reported weight by the DNS server will be used.
--- @param balancer the balancer object the host belongs to
--- @return new host object, does not fail.
-local newHost = function(hostname, port, weight, balancer)
-  local host = {
-    -- properties
-    hostname = hostname,
-    port = port,          -- if set, the port to use for A and AAAA records
-    weight = 0,           -- overall weight of all addresses within this hostname
-    nodeWeight = weight,  -- weight for entries by this host, for A and AAAA records only
-    balancer = balancer,  -- the balancer this host belongs to
-    lastQuery = nil,      -- last succesful dns query performed
-    lastSorted = nil,     -- last succesful dns query, sorted for comparison
-    addresses = {},       -- list of addresses (address objects) this host resolves to
-    expire = nil,         -- time when the dns query this host is based upon expires
-    log_prefix = balancer.log_prefix
-  }
-  for name, method in pairs(objHost) do host[name] = method end
-
-  -- insert into our parent balancer before recalculating (in queryDns)
-  -- This should actually be a responsibility of the balancer object, but in
-  -- this case we do it here, because it is needed before we can redistribute
-  -- the indices in the queryDns method just below.
-  balancer.hosts[#balancer.hosts+1] = host
-
-  ngx_log(ngx_DEBUG, balancer.log_prefix, "created a new host for: ", hostname)
-
-  host:queryDns()
-
-  return host
-end
+--  return host
+--end
 
 
 -- ===========================================================================
 -- Balancer object.
--- Manages a set of hostnames, to balance the requests over.
 -- ===========================================================================
-
-local objBalancer = {}
-
--- Address iterator.
--- Iterates over all addresses in the balancer (nested through the hosts)
--- @return weight (number), address (address object), host (host object the address belongs to)
-function objBalancer:addressIter()
-  local host_idx = 1
-  local addr_idx = 1
-  return function()
-    local host = self.hosts[host_idx]
-    if not host then return end -- done
-
-    local addr
-    while not addr do
-      addr = host.addresses[addr_idx]
-      if addr then
-        addr_idx = addr_idx + 1
-        return addr.weight, addr, host
-      end
-      addr_idx = 1
-      host_idx = host_idx + 1
-      host = self.hosts[host_idx]
-      if not host then return end -- done
-    end
-  end
-end
 
 -- Recalculates the weights. Updates the indices assigned for all hostnames.
 -- Must be called whenever a weight might have changed; added/removed hosts.
 -- @return balancer object
-function objBalancer:redistributeIndices()
+function ring_balancer:redistributeIndices()
   local totalWeight = self.weight
   local movingIndexList = self.unassignedWheelIndices
 
@@ -728,72 +243,9 @@ function objBalancer:redistributeIndices()
   return self
 end
 
---- Adds a host to the balancer. If the name resolves to multiple entries,
--- each entry will be added, all with the same weight. So adding an A record
--- with 2 entries, with weight 10, will insert both entries with weight 10,
--- and increase to overall balancer weight by 20. The one exception is that if
--- it resolves to a record with `ttl=0`, then it will __always__ only insert a single
--- (unresolved) entry. The unresolved entry will be resolved by `getPeer` when
--- requested.
---
--- Resolving will be done by the dns clients `resolve` method. Which will
--- dereference CNAME record if set to, but it will not dereference SRV records.
--- An unresolved SRV `target` field will also be resolved by `getPeer` when requested.
---
--- Only the wheel indices assigned to the newly added targets will loose their
--- consistency, all other wheel indices are guaranteed to remain the same.
---
--- Within a balancer the combination of `hostname` and `port` must be unique, so
--- multiple calls with the same target will only update the `weight` of the
--- existing entry.
---
--- __multi-server/worker consistency__; to keep multiple servers/workers consistent it is
--- important to apply all modifications to the ring-balancer in the exact same
--- order on each system. Also the initial `order` list must be the same. And; do
--- not use names, only ip adresses, as dns resolution is non-deterministic
--- across servers/workers.
--- @function addHost
--- @param hostname hostname to add (note: not validated, as long as it's a
--- string it will be accepted, but remain unresolved!)
--- @param port (optional) the port to use (defaults to 80 if omitted)
--- @param weight (optional) relative weight for A/AAAA records (defaults to
--- 10 if omitted), and will be ignored in case of an SRV record.
--- @return balancer object, or throw an error on bad input
-function objBalancer:addHost(hostname, port, weight)
-  assert(type(hostname) == "string", "expected a hostname (string), got "..tostring(hostname))
-  port = port or DEFAULT_PORT
-  weight = weight or DEFAULT_WEIGHT
-  assert(type(weight) == "number" and
-         math_floor(weight) == weight and
-         weight >= 1,
-         "Expected 'weight' to be an integer >= 1; got "..tostring(weight))
 
-  local host
-  for _, host_entry in ipairs(self.hosts) do
-    if host_entry.hostname == hostname and host_entry.port == port then
-      -- found it
-      host = host_entry
-      break
-    end
-  end
-
-  if not host then
-    -- create the new host, that will insert itself in the balancer
-    newHost(hostname, port, weight, self)
-  else
-    -- this one already exists, update if different
-    ngx_log(ngx_DEBUG, self.log_prefix, "host ", hostname, ":", port,
-            " already exists, updating weight ",
-            host.nodeWeight, "-> ",weight)
-
-    if host.nodeWeight ~= weight then
-      -- weight changed, go update
-      if host:change(weight) then
-        -- update had an impact so must redistribute indices
-        self:redistributeIndices()
-      end
-    end
-  end
+function ring_balancer:addHost(hostname, port, weight)
+  self.super.addHost(self, hostname, port, weight)
 
   if #self.unassignedWheelIndices == 0 then
     self.unassignedWheelIndices = {}  -- replace table because of initial memory footprint
@@ -801,69 +253,35 @@ function objBalancer:addHost(hostname, port, weight)
   return self
 end
 
---- Removes a host from a balancer. All assigned indices will be redistributed
--- to the remaining targets. Only the indices from the removed host will loose
--- their consistency, all other indices are guaranteed to remain in place.
--- Will not throw an error if the hostname is not in the current list.
---
--- See `addHost` for multi-server consistency.
--- @function removeHost
--- @param hostname hostname to remove
--- @param port port to remove (optional, defaults to 80 if omitted)
--- @return balancer object, or an error on bad input
-function objBalancer:removeHost(hostname, port)
-  assert(type(hostname) == "string", "expected a hostname (string), got "..tostring(hostname))
-  port = port or DEFAULT_PORT
-  for i, host in ipairs(self.hosts) do
-    if host.hostname == hostname and host.port == port then
 
-      ngx_log(ngx_DEBUG, self.log_prefix, "removing host ", hostname, ":", port)
+function ring_balancer:afterHostUpdate(host)
+  -- recalculate to move indices of added/disabled addresses
+  self:redistributeIndices()
+  return self.super.afterHostUpdate(self, host)
+end
 
-      -- set weights to 0
-      host:disable()
 
-      -- removing hosts must always be recalculated to make sure
-      -- its order is deterministic (only dns updates are not)
-      self:redistributeIndices()
+function ring_balancer:beforeHostDelete(host)
+  -- recalculate to move indices of disabled hosts
+  self:redistributeIndices()
+  return self.super.beforeHostDelete(self, host)
+end
 
-      -- remove host
-      host:delete()
-      table_remove(self.hosts, i)
-      break
-    end
-  end
+
+function ring_balancer:removeHost(hostname, port)
+  self.super.removeHost(self, hostname, port)
+
   if #self.unassignedWheelIndices == 0 then
     self.unassignedWheelIndices = {}  -- replace table because of initial memory footprint
   end
   return self
 end
 
--- Updates the total weight.
--- @param delta the in/decrease of the overall weight (negative for decrease)
-function objBalancer:addWeight(delta)
-  self.weight = self.weight + delta
-end
 
---- Gets the next ip address and port according to the loadbalancing scheme.
--- If the dns record attached to the requested wheel index is expired, then it will
--- be renewed and as a consequence the ring-balancer might be updated.
---
--- If the wheel index that is requested holds either an unresolved SRV entry (where
--- the `target` field contains a name instead of an ip), or a record with `ttl=0` then
--- this call will perform the final query to resolve to an ip using the `toip`
--- function of the dns client (this also invokes the loadbalancing as done by
--- the `toip` function).
--- @function getPeer
--- @param hashValue (optional) number for consistent hashing, round-robins if
--- omitted. The hashValue must be an (evenly distributed) `integer >= 0`. See also `hash`.
--- @param retryCount should be 0 (or `nil`) on the initial try, 1 on the first
--- retry, etc. If provided, it will be added to the `hashValue` to make it fall-through.
--- @param cacheOnly If truthy, no dns lookups will be done, only cache.
--- @return `ip + port + hostname`, or `nil+error`
-function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
+function ring_balancer:getPeer(hashValue, retryCount, cacheOnly)
   local pointer
   if self.weight == 0 then
-    return nil, ERR_NO_PEERS_AVAILABLE
+    return nil, balancer_base.errors.ERR_NO_PEERS_AVAILABLE
   end
 
   -- calculate starting point
@@ -883,20 +301,23 @@ function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
   local initial_pointer = pointer
   while true do
     local address = self.wheel[pointer]
-    local ip, port, hostname = address.host:getPeer(cacheOnly, address)
+    local ip, port, hostname = address:getPeer(cacheOnly)
     if ip then
       return ip, port, hostname
-    elseif port == ERR_INDEX_REASSIGNED then
+
+    elseif port == balancer_base.errors.ERR_DNS_UPDATED then
       -- we just need to retry the same index, no change for 'pointer', just
       -- in case of dns updates, we need to check our weight again.
       if self.weight == 0 then
-        return nil, ERR_NO_PEERS_AVAILABLE
+        return nil, balancer_base.errors.ERR_NO_PEERS_AVAILABLE
       end
-    elseif port == ERR_ADDRESS_UNAVAILABLE then
+
+    elseif port == balancer_base.errors.ERR_ADDRESS_UNAVAILABLE then
       -- fall through to the next wheel index
       if hashValue then
         pointer = pointer + 1
         if pointer > self.wheelSize then pointer = 1 end
+
       else
         pointer = self.pointer
         if pointer < self.wheelSize then
@@ -905,10 +326,12 @@ function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
           self.pointer = 1
         end
       end
+
       if pointer == initial_pointer then
         -- we went around, but still nothing...
-        return nil, ERR_NO_PEERS_AVAILABLE
+        return nil, balancer_base.errors.ERR_NO_PEERS_AVAILABLE
       end
+
     else
       -- an unknown error occured
       return nil, port
@@ -917,109 +340,6 @@ function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
 
 end
 
---- Sets the current status of the peer.
--- This allows to temporarily suspend peers when they are offline/unhealthy,
--- it will not alter the index distribution. The parameters passed in should
--- be previous results from `getPeer`.
--- @function setPeerStatus
--- @param available `true` for enabled/healthy, `false` for disabled/unhealthy
--- @param ip ip address of the peer
--- @param port the port of the peer (in address object, not as recorded with the Host!)
--- @param hostname (optional, defaults to the value of `ip`) the hostname
--- @return `true` on success, or `nil+err` if not found
-function objBalancer:setPeerStatus(available, ip, port, hostname)
-  hostname = hostname or ip
-  local name_srv = {}
-  for _, addr, host in self:addressIter() do
-    if host.hostname == hostname and addr.port == port then
-      if addr.ip == ip then
-        -- found it
-        addr:setState(available)
-        return true
-      elseif addr.ipType == "name" then
-        -- so.... the ip is a name. This means that the host that
-        -- was added most likely resolved to an SRV, which then has
-        -- in turn names as targets instead of ip addresses.
-        -- (possibly a fake SRV for ttl=0 records)
-        -- Those names are resolved last minute by `getPeer`.
-        -- TLDR: we don't track the IP in this case, so we cannot match the
-        -- inputs back to an address to disable/enable it.
-        -- We record this fact here, and if we have no match in the end
-        -- we can provide a more specific message
-        name_srv[#name_srv + 1] = addr.ip .. ":" .. addr.port
-      end
-    end
-  end
-  local msg = ("no peer found by name '%s' and address %s:%s"):format(hostname, ip, tostring(port))
-  if name_srv[1] then
-    -- no match, but we did find a named one, so making the message more explicit
-    msg = msg .. ", possibly the IP originated from these nested dns names: " ..
-          table_concat(name_srv, ",")
-    ngx_log(ngx_WARN, self.log_prefix, msg)
-  end
-  return nil, msg
-end
-
--- Timer invoked to check for failed queries
-local function timerCallback(premature, self)
-  if premature then return end
-
-  ngx_log(ngx_DEBUG, self.log_prefix, "executing requery timer")
-
-  local all_ok = true
-  for _, host in ipairs(self.hosts) do
-    -- only retry the errorred ones
-    if host.lastQuery.__errorQueryFlag then
-      all_ok = false -- note: only if NO requery at all is done, we are 'all_ok'
-      -- if even a single dns query is performed, we yield on the dns socket
-      -- operation and our universe might have changed. Could lead to nasty
-      -- race-conditions otherwise.
-      host:queryDns(false) -- timer-context; cacheOnly always false
-    end
-  end
-
-  if all_ok then
-    -- shutdown recurring timer
-    ngx_log(ngx_DEBUG, self.log_prefix, "requery success, stopping timer")
-    self.requeryRunning = false
-  else
-    -- not done yet, reschedule timer
-    ngx_log(ngx_DEBUG, self.log_prefix, "requery failure, rescheduling timer")
-    local ok, err = gctimer(self.requeryInterval, timerCallback, self)
-    if not ok then
-      ngx_log(ngx_ERR, self.log_prefix, "failed to create the timer: ", err)
-    end
-  end
-end
-
--- Starts the requery timer.
-function objBalancer:startRequery()
-  if self.requeryRunning then return end  -- already running, nothing to do here
-
-  self.requeryRunning = true
-  local ok, err = gctimer(self.requeryInterval, timerCallback, self)
-  if not ok then
-    ngx_log(ngx_ERR, self.log_prefix, "failed to create the timer: ", err)
-  end
-end
-
---- Sets an event callback for user code.
--- Signature of the callback is:
---
---   `function(balancer, action, ip, port, hostname)`
---
--- where `ip` might also
--- be a hostname if the DNS resolution returns another name (usually in
--- SRV records). The `action` parameter will be either `"added"` or `"removed"`.
--- @function setCallback
--- @param callback a function called when an address is added (after DNS
--- resolution for example).
--- @return `true`, or throws an error on bad input
-function objBalancer:setCallback(callback)
-  assert(type(callback) == "function", "expected a callback function")
-  self.callback = callback
-  return true
-end
 
 local randomlist_cache = {}
 
@@ -1053,10 +373,6 @@ end
 -- indices will be randomly distributed over the targets. The number of indices
 -- assigned will be relative to the weight.
 --
--- A single balancer can hold multiple hosts. A host can be an ip address or a
--- name. As such each host can have multiple targets (or actual ip+port
--- combinations).
---
 -- The options table has the following fields;
 --
 -- - `hosts` (optional) containing hostnames, ports and weights. If omitted,
@@ -1076,7 +392,6 @@ end
 -- seems about right.
 -- - `order` (optional) if given, a list of random numbers, size `wheelSize`, used to
 -- randomize the wheel. Duplicates are not allowed in the list.
--- - `dns` (required) a configured `dns.client` object for querying the dns server.
 -- - `requery` (optional) interval of requerying the dns server for previously
 -- failed queries. Defaults to 1 if omitted (in seconds)
 -- - `ttl0` (optional) Maximum lifetime for records inserted with `ttl=0`, to verify
@@ -1091,37 +406,34 @@ end
 --   { name = "github.com" },                           -- name only, as table
 --   { name = "getkong.org", port = 80, weight = 25 },  -- fully specified, as table
 -- }
-_M.new = function(opts)
+function _M.new(opts)
   assert(type(opts) == "table", "Expected an options table, but got: "..type(opts))
-  assert(opts.dns, "expected option `dns` to be a configured dns client")
+  if not opts.log_prefix then
+    opts.log_prefix = "ringbalancer"
+  end
+
+  local self = balancer_base.new(opts)
+
   if (not opts.wheelSize) and opts.order then
     opts.wheelSize = #opts.order
   end
   if opts.order then
     assert(opts.order and (opts.wheelSize == #opts.order), "mismatch between size of 'order' and 'wheelSize'")
   end
-  assert((opts.requery or 1) > 0, "expected 'requery' parameter to be > 0")
-  assert((opts.ttl0 or 1) > 0, "expected 'ttl0' parameter to be > 0")
-  assert(type(opts.callback) == "function" or type(opts.callback) == "nil",
-    "expected 'callback' to be a function or nil, but got: " .. type(opts.callback))
 
-  balancer_id_counter = balancer_id_counter + 1
-  local self = {
-    -- properties
-    log_prefix = "[ringbalancer " .. tostring(balancer_id_counter) .. "] ",
-    hosts = {},    -- a table, index by both the hostname and index, the value being a host object
-    weight = 0,    -- total weight of all hosts
-    wheel = nil,   -- wheel with entries (fully randomized)
-    pointer = nil, -- pointer to next-up index for the round robin scheme
-    wheelSize = opts.wheelSize or 1000, -- number of entries (indices) in the wheel
-    dns = opts.dns,  -- the configured dns client to use for resolving
-    unassignedWheelIndices = nil, -- list to hold unassigned indices (initially, and when all hosts fail)
-    requeryRunning = false,  -- requery timer is not running, see `startRequery`
-    requeryInterval = opts.requery or REQUERY_INTERVAL,  -- how often to requery failed dns lookups (seconds)
-    ttl0Interval = opts.ttl0 or TTL_0_RETRY, -- refreshing ttl=0 records
-    callback = opts.callback or function() end, -- callback for address mutations
-  }
-  for name, method in pairs(objBalancer) do self[name] = method end
+  -- inject additional properties
+  self.wheel = nil   -- wheel with entries (fully randomized)
+  self.pointer = nil -- pointer to next-up index for the round robin scheme
+  self.wheelSize = opts.wheelSize or 1000 -- number of entries (indices) in the wheel
+  self.unassignedWheelIndices = nil -- list to hold unassigned indices (initially, and when all hosts fail)
+
+  -- inject overridden methods
+  for name, method in pairs(ring_balancer) do
+    self[name] = method
+  end
+
+  -- initialize the balancer
+
   self.wheel = new_tab(self.wheelSize, 0)
   self.unassignedWheelIndices = new_tab(self.wheelSize, 0)
   self.pointer = math.random(1, self.wheelSize)  -- ensure each worker starts somewhere else
@@ -1160,7 +472,8 @@ _M.new = function(opts)
     end
   end
 
-  ngx_log(ngx_DEBUG, self.log_prefix, "balancer created")
+  ngx_log(ngx_DEBUG, self.log_prefix, "ringbalancer created")
+
   return self
 end
 

--- a/src/resty/dns/balancer_base.lua
+++ b/src/resty/dns/balancer_base.lua
@@ -1,0 +1,1034 @@
+--------------------------------------------------------------------------
+-- __Base-balancer__
+--
+-- The base class for balancers. It implements DNS resolution and fanning
+-- out hostnames to addresses. It builds and maintains a tree structure:
+--
+--   `balancer <1 --- many> hosts <1 --- many> addresses`
+--
+-- Updating the dns records is passive, meaning that when `getPeer` accesses a
+-- target, only then the check is done whether the record is stale, and if so
+-- it is updated. The one exception is the failed dns queries (because they
+-- have no indices assigned, and hence will never be hit by `getPeer`), which will
+-- be actively refreshed using a timer.
+--
+-- __Weights__
+--
+-- Weights will be tracked as follows. Since a Balancer has multiple Hosts, and
+-- a Host has multiple Addresses. The Host weight will be the sum of all its
+-- addresses, and the Balancer weight will be the sum of all Hosts.
+-- See `addHost` on how to set the weight for an `address`.
+--
+-- The weight of each `address` will be the weight provided as `nodeWeight` when adding
+-- a `host`. So adding a `host` with weight 20, that resolves to 2 IP addresses, will
+-- insert 2 `addresses` each with a weight of 20, totalling the weight of the `host` to
+-- 40.
+--
+-- Exception 1: If the `host` resolves to an SRV record, in which case each
+-- `address` gets the weight as specified in the DNS record. In this case the
+-- `nodeWeight` property will be ignored.
+--
+-- Exception 2: If the DNS record for the `host` has a `ttl=0` then the record contents
+-- will be ignored, and a single address with the original hostname will be
+-- inserted. This address will get a weight assigned of `nodeWeight`.
+-- Whenever the balancer hits this address, it will be resolved on the spot, hence
+-- honouring the `ttl=0` value.
+--
+-- __Adding and resolving hosts__
+--
+-- When adding a host, it will be resolved and for each entry an `address` will be
+-- added. With the exception of a `ttl=0` setting as noted above. When resolving the
+-- names, any CNAME records will be dereferenced immediately, any other records
+-- will not.
+--
+-- _Example 1: add an IP address "127.0.0.1"_
+--
+-- The host object will resolve the name, and since it's and IP address it
+-- returns a single A record with 1 entry, that same IP address.
+--
+--    host object 1   : hostname="127.0.0.1"  --> since this is the name added
+--    address object 1: ip="127.0.0.1"        --> single IP address
+--
+-- _Example 2: complex DNS lookup chain_
+--
+-- assuming the following lookup chain for a `host` added by name `"myhost"`:
+--
+--    myhost    --> CNAME yourhost
+--    yourhost  --> CNAME herhost
+--    herhost   --> CNAME theirhost
+--    theirhost --> SRV with 2 entries: host1.com, host2.com
+--    host1.com --> A with 1 entry: 192.168.1.10
+--    host2.com --> A with 1 entry: 192.168.1.11
+--
+-- Adding a host by name `myhost` will first create a `host` by name `myhost`. It will then
+-- resolve the name `myhost`, the CNAME chain will be dereferenced immediately, so the
+-- result will be an SRV record with 2 named entries. The names will be used for the
+-- addresses:
+--
+--    host object 1   : hostname="myhost"
+--    address object 1: ip="host1.com"  --> NOT an ip, but a name!
+--    address object 2: ip="host2.com"  --> NOT an ip, but a name!
+--
+-- When the balancer hits these addresses (when calling `getPeer`), it will
+-- dereference them (so they will be resolved at balancer-runtime, not at
+-- balancer-buildtime).
+--
+-- __Clustering__
+--
+-- The balancer is deterministic in the way it adds/removes elements. So as long as
+-- the confguration is the same, and adding/removing hosts is done in the same order
+-- the exact same balancer will be created. This is important in case of
+-- consistent-hashing approaches, since each cluster member needs to behave the same.
+--
+-- _NOTE_: there is one caveat, DNS resolution is not deterministic, because timing
+-- differences might cause different orders of adding/removing. Hence the structures
+-- can potentially slowly diverge. If this is unacceptable, make sure you do not
+-- invlove DNS by adding hosts by their IP adresses instead of their hostname.
+--
+-- __Housekeeping__
+--
+-- The balancer does some house keeping and may insert
+-- some extra fields in dns records. Those fields will have an `__` prefix
+-- (double underscores).
+--
+-- @author Thijs Schreijer
+-- @copyright 2016-2018 Kong Inc. All rights reserved.
+-- @license Apache 2.0
+
+
+local DEFAULT_WEIGHT = 10   -- default weight for a host, if not provided
+local DEFAULT_PORT = 80     -- Default port to use (A and AAAA only) when not provided
+local TTL_0_RETRY = 60      -- Maximum life-time for hosts added with ttl=0, requery after it expires
+local REQUERY_INTERVAL = 30 -- Interval for requerying failed dns queries
+
+local dns_client = require "resty.dns.client"
+local dns_utils = require "resty.dns.utils"
+local resty_timer = require "resty.timer"
+local time = ngx.now
+local table_sort = table.sort
+local table_remove = table.remove
+local table_concat = table.concat
+local math_floor = math.floor
+local string_format = string.format
+local ngx_log = ngx.log
+local ngx_ERR = ngx.ERR
+local ngx_DEBUG = ngx.DEBUG
+local ngx_WARN = ngx.WARN
+local balancer_id_counter = 0
+
+local empty = setmetatable({},
+  {__newindex = function() error("The 'empty' table is read-only") end})
+
+local errors = setmetatable({
+  ERR_DNS_UPDATED = "Cannot get peer, a DNS update changed the balancer structure, please retry",
+  ERR_ADDRESS_UNAVAILABLE = "Address is marked as unavailable",
+  ERR_NO_PEERS_AVAILABLE = "No peers are available",
+}, {
+  __index = function(self, key)
+    error("invalid key: " .. tostring(key))
+  end
+})
+
+
+local _M = {}
+
+
+-- Address object metatable to use for inheritance
+local objAddr = {}
+local mt_objAddr = { __index = objAddr }
+local objHost = {}
+local mt_objHost = { __index = objHost }
+local objBalancer = {}
+local mt_objBalancer = { __index = objBalancer }
+
+------------------------------------------------------------------------------
+-- Implementation properties.
+-- These properties are only relevant for implementing a new balancer algorithm
+-- using this base class. To use a balancer see the _User properties_ section.
+-- @section implementation
+
+
+-- ===========================================================================
+-- address object.
+-- Manages an ip address. It is generated by resolving a `host`, hence a single
+-- `host` can have multiple `addresses` associated.
+-- ===========================================================================
+
+-- Returns the peer info.
+-- @return ip-address, port and hostname of the target, or nil+err if unavailable
+-- or lookup error
+function objAddr:getPeer(cacheOnly)
+  if not self.available then
+    return nil, errors.ERR_ADDRESS_UNAVAILABLE
+  end
+
+  -- check with our Host whether the DNS record is still up to date
+  if not self.host:addressStillValid(cacheOnly, self) then
+    -- DNS expired, and this address was removed
+    return nil, errors.ERR_DNS_UPDATED
+  end
+
+  if self.ipType == "name" then
+    -- SRV type record with a named target
+    local ip, port, try_list = dns_client.toip(self.ip, self.port, cacheOnly)
+    if not ip then
+      port = tostring(port) .. ". Tried: " .. tostring(try_list)
+    end
+    -- which is the proper name to return in this case?
+    -- `self.host.hostname`? or the named SRV entry: `self.ip`?
+    -- use our own hostname, as it might be used to mark this address
+    -- as unhealthy, so we must be able to find it
+    return ip, port, self.host.hostname
+  else
+    -- just an IP address
+    return self.ip, self.port, self.host.hostname
+  end
+end
+
+-- disables an address object from the balancer.
+-- It will set its weight to 0, and the `disabled` flag to `true`.
+-- @see delete
+function objAddr:disable()
+  ngx_log(ngx_DEBUG, self.log_prefix, "disabling address: ", self.ip, ":", self.port,
+          " (host ", (self.host or empty).hostname, ")")
+
+  -- weight to 0; effectively disabling it
+  self:change(0)
+  self.disabled = true
+end
+
+-- Cleans up an address object.
+-- The address must have been disabled before.
+-- @see disable
+function objAddr:delete()
+  assert(self.disabled, "Cannot delete an address that wasn't disabled first")
+  ngx_log(ngx_DEBUG, self.log_prefix, "deleting address: ", self.ip, ":", self.port,
+          " (host ", (self.host or empty).hostname, ")")
+
+  self.host.balancer:callback("removed", self.ip,
+                              self.port, self.host.hostname)
+  self.host.balancer:onRemoveAddress(self)
+  self.host = nil
+end
+
+-- Changes the weight of an address.
+function objAddr:change(newWeight)
+  ngx_log(ngx_DEBUG, self.log_prefix, "changing address weight: ", self.ip, ":", self.port,
+          "(host ", (self.host or empty).hostname, ") ",
+          self.weight, " -> ", newWeight)
+
+  self.host:addWeight(newWeight - self.weight)
+  self.weight = newWeight
+end
+
+-- Set the availability of the address.
+function objAddr:setState(available)
+  self.available = not not available -- force to boolean
+end
+
+
+--- Creates a new address object. There is no need to call this from user code.
+-- When implementing a new balancer algorithm, you might want to override this method.
+-- The `addr` table should contain:
+--
+-- - `ip`: the upstream ip address or target name
+-- - `port`: the upstream port number
+-- - `weight`: the relative weight for the balancer algorithm
+-- - `host`: the host object the new address belongs to
+-- @param addr table to be transformed to Address object
+-- @return new address object, or error on bad input
+function objBalancer:newAddress(addr)
+  assert(type(addr.ip) == "string", "Expected 'ip' to be a string, got: " .. type(addr.ip))
+  assert(type(addr.port) == "number", "Expected 'port' to be a number, got: " .. type(addr.port))
+  assert(addr.port > 0 and addr.port < 65536, "Expected 'port` to be between 0 and 65536, got: " .. addr.port)
+  assert(type(addr.weight) == "number", "Expected 'weight' to be a number, got: " .. type(addr.weight))
+  assert(addr.weight >= 0, "Expected 'weight' to be equal or greater than 0, got: " .. addr.weight)
+  assert(type(addr.host) == "table", "Expected 'host' to be a table, got: " .. type(addr.host))
+  assert(getmetatable(addr.host) == mt_objHost, "Expected 'host' to be an objHost type")
+
+  addr = setmetatable(addr, mt_objAddr)
+  addr.super = objAddr
+  addr.ipType = dns_utils.hostnameType(addr.ip)  -- 'ipv4', 'ipv6' or 'name'
+  addr.log_prefix = addr.host.log_prefix
+  addr.available = true      -- is this target available?
+  addr.disabled = false      -- has this record been disabled? (before deleting)
+
+  addr.host:addWeight(addr.weight)
+
+  ngx_log(ngx_DEBUG, addr.host.log_prefix, "new address for host '", addr.host.hostname,
+          "' created: ", addr.ip, ":", addr.port, " (weight ", addr.weight,")")
+  addr.host.balancer:callback("added", addr.ip, addr.port, addr.host.hostname)
+  addr.host.balancer:onAddAddress(addr)
+  return addr
+end
+
+
+-- ===========================================================================
+-- Host object.
+-- Manages a single hostname, with DNS resolution and expanding into
+-- multiple `address` objects.
+-- ===========================================================================
+
+-- define sort order for DNS query results
+local sortQuery = function(a,b) return a.__balancerSortKey < b.__balancerSortKey end
+local sorts = {
+  [dns_client.TYPE_A] = function(result)
+    local sorted = {}
+    -- build table with keys
+    for i, v in ipairs(result) do
+      sorted[i] = v
+      v.__balancerSortKey = v.address
+    end
+    -- sort by the keys
+    table_sort(sorted, sortQuery)
+    -- reverse index
+    for i, v in ipairs(sorted) do sorted[v.__balancerSortKey] = i end
+    return sorted
+  end,
+  [dns_client.TYPE_SRV] = function(result)
+    local sorted = {}
+    -- build table with keys
+    for i, v in ipairs(result) do
+      sorted[i] = v
+      v.__balancerSortKey = string_format("%06d:%s:%s:%s", v.priority, v.target, v.port, v.weight)
+    end
+    -- sort by the keys
+    table_sort(sorted, sortQuery)
+    -- reverse index
+    for i, v in ipairs(sorted) do sorted[v.__balancerSortKey] = i end
+    return sorted
+  end,
+}
+sorts[dns_client.TYPE_AAAA] = sorts[dns_client.TYPE_A] -- A and AAAA use the same sorting order
+sorts = setmetatable(sorts,{
+    -- all record types not mentioned above are unsupported, throw error
+    __index = function(self, key)
+      error("Unknown/unsupported DNS record type; "..tostring(key))
+    end,
+  })
+
+-- Queries the DNS for this hostname. Updates the underlying address objects.
+-- This method always succeeds, but it might leave the balancer in a 0-weight
+-- state if none of the hosts resolves.
+-- @return `true`, always succeeds
+function objHost:queryDns(cacheOnly)
+
+  ngx_log(ngx_DEBUG, self.log_prefix, "querying dns for ", self.hostname)
+
+  -- first thing we do is the dns query, this is the only place we possibly
+  -- yield (cosockets in the dns lib). So once that is done, we're 'atomic'
+  -- again, and we shouldn't have any nasty race conditions
+  local dns = self.balancer.dns
+  local newQuery, err, try_list = dns.resolve(self.hostname, nil, cacheOnly)
+
+  local oldQuery = self.lastQuery or {}
+  local oldSorted = self.lastSorted or {}
+
+  if err then
+    ngx_log(ngx_WARN, self.log_prefix, "querying dns for ", self.hostname,
+            " failed: ", err , ". Tried ", tostring(try_list))
+
+    -- query failed, create a fake recorded, flagged as failed.
+    -- the empty record will cause all existing addresses to be removed
+    newQuery = {
+      __errorQueryFlag = true  --flag to mark the record as a failed lookup
+    }
+    self.balancer:startRequery()
+  end
+
+  -- we're using the dns' own cache to check for changes.
+  -- if our previous result is the same table as the current result, then nothing changed
+  if oldQuery == newQuery then
+    ngx_log(ngx_DEBUG, self.log_prefix, "no dns changes detected for ", self.hostname)
+
+    return true    -- exit, nothing changed
+  end
+
+  -- To detect ttl = 0 we validate both the old and new record. This is done to ensure
+  -- we do not hit the edgecase of https://github.com/Kong/lua-resty-dns-client/issues/51
+  -- So if we get a ttl=0 twice in a row (the old one, and the new one), we update it. And
+  -- if the very first request ever reports ttl=0 (we assume we're not hitting the edgecase
+  -- in that case)
+  if (newQuery[1] or empty).ttl == 0 and ((oldQuery[1] or empty).ttl or 0) == 0 then
+    -- ttl = 0 means we need to lookup on every request.
+    -- To enable lookup on each request we 'abuse' a virtual SRV record. We set the ttl
+    -- to `ttl0Interval` seconds, and set the `target` field to the hostname that needs
+    -- resolving. Now `getPeer` will resolve on each request if the target is not an IP address,
+    -- and after `ttl0Interval` seconds we'll retry to see whether the ttl has changed to non-0.
+    -- Note: if the original record is an SRV we cannot use the dns provided weights,
+    -- because we can/are not going to possibly change weights on each request
+    -- so we fix them at the `nodeWeight` property, as with A and AAAA records.
+    if oldQuery.__ttl0Flag then
+      -- still ttl 0 so nothing changed
+      ngx_log(ngx_DEBUG, self.log_prefix, "no dns changes detected for ",
+              self.hostname, ", still using ttl=0")
+      return true
+    end
+    ngx_log(ngx_DEBUG, self.log_prefix, "ttl=0 detected for ",
+            self.hostname)
+    newQuery = {
+        {
+          type = dns.TYPE_SRV,
+          target = self.hostname,
+          name = self.hostname,
+          port = self.port,
+          weight = self.nodeWeight,
+          priority = 1,
+          ttl = self.balancer.ttl0Interval,
+        },
+        expire = time() + self.balancer.ttl0Interval,
+        touched = time(),
+        __ttl0Flag = true,        -- flag marking this record as a fake SRV one
+      }
+  end
+
+  -- a new dns record, was returned, but contents could still be the same, so check for changes
+  -- sort table in unique order
+  local rtype = (newQuery[1] or empty).type
+  if not rtype then
+    -- we got an empty query table, so assume A record, because it's empty
+    -- all existing addresses will be removed
+    ngx_log(ngx_DEBUG, self.log_prefix, "blank dns record for ",
+              self.hostname, ", assuming A-record")
+    rtype = dns.TYPE_A
+  end
+  local newSorted = sorts[rtype](newQuery)
+  local dirty
+
+  if rtype ~= (oldSorted[1] or empty).type then
+    -- DNS recordtype changed; recycle everything
+    ngx_log(ngx_DEBUG, self.log_prefix, "dns record type changed for ",
+            self.hostname, ", ", (oldSorted[1] or empty).type, " -> ",rtype)
+    for i = #oldSorted, 1, -1 do  -- reverse order because we're deleting items
+      self:disableAddress(oldSorted[i])
+    end
+    for _, entry in ipairs(newSorted) do -- use sorted table for deterministic order
+      self:addAddress(entry)
+    end
+    dirty = true
+  else
+    -- new record, but the same type
+    local topPriority = (newSorted[1] or empty).priority -- nil for non-SRV records
+    local done = {}
+    local dCount = 0
+    for _, newEntry in ipairs(newSorted) do
+      if newEntry.priority ~= topPriority then break end -- exit when priority changes, as SRV only uses top priority
+
+      local key = newEntry.__balancerSortKey
+      local oldEntry = oldSorted[oldSorted[key] or "__key_not_found__"]
+      if not oldEntry then
+        -- it's a new entry
+        ngx_log(ngx_DEBUG, self.log_prefix, "new dns record entry for ",
+                self.hostname, ": ", (newEntry.target or newEntry.address),
+                ":", newEntry.port) -- port = nil for A or AAAA records
+        self:addAddress(newEntry)
+        dirty = true
+      else
+        -- it already existed (same ip, port and weight)
+        ngx_log(ngx_DEBUG, self.log_prefix, "unchanged dns record entry for ",
+                self.hostname, ": ", (newEntry.target or newEntry.address),
+                ":", newEntry.port) -- port = nil for A or AAAA records
+        done[key] = true
+        dCount = dCount + 1
+      end
+    end
+    if dCount ~= #oldSorted then
+      -- not all existing entries were handled, remove the ones that are not in the
+      -- new query result
+      for _, entry in ipairs(oldSorted) do
+        if not done[entry.__balancerSortKey] then
+          ngx_log(ngx_DEBUG, self.log_prefix, "removed dns record entry for ",
+                  self.hostname, ": ", (entry.target or entry.address),
+                  ":", entry.port) -- port = nil for A or AAAA records
+          self:disableAddress(entry)
+        end
+      end
+      dirty = true
+    end
+  end
+
+  self.lastQuery = newQuery
+  self.lastSorted = newSorted
+
+  if dirty then
+    -- above we already added and updated records. Removed addresses are disabled, and
+    -- need yet to be deleted from the Host
+    ngx_log(ngx_DEBUG, self.log_prefix, "updating balancer based on dns changes for ",
+            self.hostname)
+
+    -- allow balancer to update its algorithm
+    self.balancer:afterHostUpdate(self)
+
+    -- delete addresses previously disabled
+    self:deleteAddresses()
+  end
+
+  ngx_log(ngx_DEBUG, self.log_prefix, "querying dns and updating for ", self.hostname, " completed")
+  return true
+end
+
+-- Changes the host overall weight. It will also update the parent balancer object.
+-- This will be called by the `address` object whenever it changes its weight.
+function objHost:addWeight(delta)
+  self.weight = self.weight + delta
+  self.balancer:addWeight(delta)
+end
+
+-- Updates the host nodeWeight.
+-- @return `true` if something changed that might impact the balancer algorithm
+function objHost:change(newWeight)
+  local dirty = false
+  self.nodeWeight = newWeight
+  local lastQuery = self.lastQuery or {}
+  if #lastQuery > 0 then
+    if lastQuery[1].type == dns_client.TYPE_SRV and not lastQuery.__ttl0Flag then
+      -- this is an SRV record (and not a fake ttl=0 one), which
+      -- carries its own weight setting, so nothing to update
+      ngx_log(ngx_DEBUG, self.log_prefix, "ignoring weight change for ", self.hostname,
+              " as SRV records carry their own weight")
+    else
+      -- so here we have A, AAAA, or a fake SRV, which uses the `nodeWeight` property
+      -- go update all our addresses
+      for _, addr in ipairs(self.addresses) do
+        addr:change(newWeight)
+      end
+      dirty = true
+    end
+  end
+  return dirty
+end
+
+-- Adds an `address` object to the `host`.
+-- @param entry (table) DNS entry (single entry, not the full record)
+function objHost:addAddress(entry)
+  local weight = entry.weight  -- this is nil for anything else than SRV
+  if weight == 0 then
+    -- Special case: SRV with weight = 0 should be included, but with
+    -- the lowest possible probability of being hit. So we force it to
+    -- weight 1.
+    weight = 1
+  end
+  local addresses = self.addresses
+  addresses[#addresses + 1] = self.balancer:newAddress {
+    ip = entry.address or entry.target,
+    port = (entry.port ~= 0 and entry.port) or self.port,
+    weight = weight or self.nodeWeight,
+    host = self,
+  }
+end
+
+-- Looks up and disables an `address` object from the `host`.
+-- @param entry (table) DNS entry (single entry, not the full record)
+-- @return address object that was disabled
+function objHost:disableAddress(entry)
+  -- first lookup address object
+  for _, addr in ipairs(self.addresses) do
+    if (addr.ip == (entry.address or entry.target)) and
+        addr.port == (entry.port or self.port) and
+        not addr.disabled then
+      -- found it
+      addr:disable()
+      return addr
+    end
+  end
+end
+
+-- Looks up and deletes previously disabled `address` objects from the `host`.
+-- @return `true`
+function objHost:deleteAddresses()
+  for i = #self.addresses, 1, -1 do -- deleting entries, hence reverse traversal
+    if self.addresses[i].disabled then
+      self.addresses[i]:delete()
+      table_remove(self.addresses, i)
+    end
+  end
+
+  return true
+end
+
+-- disables a host, by setting all adressess to 0
+-- Host can only be deleted after updating the balancer algorithm!
+-- @return true
+function objHost:disable()
+  -- set weights to 0
+  for _, addr in ipairs(self.addresses) do
+    addr:disable()
+  end
+
+  return true
+end
+
+-- Cleans up a host. Only when its weight is 0.
+-- Should only be called after updating the balancer algorithm!
+-- @return true or throws an error if weight is non-0
+function objHost:delete()
+  assert(self.weight == 0, "Cannot delete a host with a non-0 weight")
+
+  for i = #self.addresses, 1, -1 do  -- reverse traversal as we're deleting
+    self.addresses[i]:delete()
+  end
+
+  self.balancer = nil
+end
+
+
+function objHost:addressStillValid(cacheOnly, address)
+
+  if (self.lastQuery.expire or 0) < time() and not cacheOnly then
+    -- ttl expired, so must renew
+    self:queryDns(cacheOnly)
+
+    if (address or empty).host ~= self then
+      -- the address no longer points to this host, so it is not valid anymore
+      ngx_log(ngx_DEBUG, self.log_prefix, "DNS record for ", self.hostname,
+              " was updated and no longer contains the address")
+      return false
+    end
+  end
+
+  return true
+end
+
+--- Creates a new host object. There is no need to call this from user code.
+-- When implementing a new balancer algorithm, you might want to override this method.
+-- The `host` table should have fields:
+--
+-- - `hostname`: the upstream hostname (as used in dns queries)
+-- - `port`: the upstream port number for A and AAAA dns records. For SRV records
+--   the reported port by the DNS server will be used.
+-- - `nodeWeight`: the relative weight for the balancer algorithm to assign to each A
+--   or AAAA dns record. For SRV records the reported weight by the DNS server
+--   will be used.
+-- - `balancer`: the balancer object the host belongs to
+-- @param host table to create the host object from.
+-- @return new host object, or error on bad input.
+function objBalancer:newHost(host)
+  assert(type(host.hostname) == "string", "Expected 'host' to be a string, got: " .. type(host.hostname))
+  assert(type(host.port) == "number", "Expected 'port' to be a number, got: " .. type(host.port))
+  assert(host.port > 0 and host.port < 65536, "Expected 'port` to be between 0 and 65536, got: " .. host.port)
+  assert(type(host.nodeWeight) == "number", "Expected 'nodeWeight' to be a number, got: " .. type(host.nodeWeight))
+  assert(host.nodeWeight >= 0, "Expected 'nodeWeight' to be equal or greater than 0, got: " .. host.nodeWeight)
+  assert(type(host.balancer) == "table", "Expected 'balancer' to be a table, got: " .. type(host.balancer))
+  assert(getmetatable(host.balancer) == mt_objBalancer, "Expected 'balancer' to be an objBalancer type")
+
+  host = setmetatable(host, mt_objHost)
+  host.super = objHost
+  host.log_prefix = host.balancer.log_prefix
+  host.weight = 0           -- overall weight of all addresses within this hostname
+  host.lastQuery = nil      -- last successful dns query performed
+  host.lastSorted = nil     -- last successful dns query, sorted for comparison
+  host.addresses = {}       -- list of addresses (address objects) this host resolves to
+  host.expire = nil         -- time when the dns query this host is based upon expires
+
+
+  -- insert into our parent balancer before recalculating (in queryDns)
+  -- This should actually be a responsibility of the balancer object, but in
+  -- this case we do it here, because it is needed before we can redistribute
+  -- the indices in the queryDns method just below.
+  host.balancer.hosts[#host.balancer.hosts + 1] = host
+
+  ngx_log(ngx_DEBUG, host.balancer.log_prefix, "created a new host for: ", host.hostname)
+
+  host:queryDns()
+
+  return host
+end
+
+
+-- ===========================================================================
+-- Balancer object.
+-- Manages a set of hostnames, to balance the requests over.
+-- ===========================================================================
+
+--- List of addresses.
+-- This is a list of addresses, ordered based on when they were added.
+-- @field objBalancer.addresses
+
+--- List of hosts.
+-- This is a list of addresses, ordered based on when they were added.
+-- @field objBalancer.hosts
+
+
+-- Address iterator.
+-- Iterates over all addresses in the balancer (nested through the hosts)
+-- @return weight (number), address (address object), host (host object the address belongs to)
+function objBalancer:addressIter()
+  local host_idx = 1
+  local addr_idx = 1
+  return function()
+    local host = self.hosts[host_idx]
+    if not host then return end -- done
+
+    local addr
+    while not addr do
+      addr = host.addresses[addr_idx]
+      if addr then
+        addr_idx = addr_idx + 1
+        return addr.weight, addr, host
+      end
+      addr_idx = 1
+      host_idx = host_idx + 1
+      host = self.hosts[host_idx]
+      if not host then return end -- done
+    end
+  end
+end
+
+
+--- This method is called after changes have been made to the addresses.
+--
+-- When implementing a new balancer algorithm, you might want to override this method.
+--
+-- The call is after the addition of new, and disabling old, but before
+-- deleting old addresses.
+-- The `address.disabled` field will be `true` for addresses that are about to be deleted.
+-- @param host the `host` object that had its addresses updated
+function objBalancer:afterHostUpdate(host)
+end
+
+--- Adds a host to the balancer.
+-- The name will be resolved and for each DNS entry an `address` will be added.
+--
+-- Within a balancer the combination of `hostname` and `port` must be unique, so
+-- multiple calls with the same target will only update the `weight` of the
+-- existing entry.
+-- @return balancer object, or throw an error on bad input
+-- @within User properties
+function objBalancer:addHost(hostname, port, nodeWeight)
+  assert(type(hostname) == "string", "expected a hostname (string), got "..tostring(hostname))
+  port = port or DEFAULT_PORT
+  nodeWeight = nodeWeight or DEFAULT_WEIGHT
+  assert(type(nodeWeight) == "number" and
+         math_floor(nodeWeight) == nodeWeight and
+         nodeWeight >= 1,
+         "Expected 'weight' to be an integer >= 1; got "..tostring(nodeWeight))
+
+  local host
+  for _, host_entry in ipairs(self.hosts) do
+    if host_entry.hostname == hostname and host_entry.port == port then
+      -- found it
+      host = host_entry
+      break
+    end
+  end
+
+  if not host then
+    -- create the new host, that will insert itself in the balancer
+    self:newHost {
+      hostname = hostname,
+      port = port,
+      nodeWeight = nodeWeight,
+      balancer = self
+    }
+  else
+    -- this one already exists, update if different
+    ngx_log(ngx_DEBUG, self.log_prefix, "host ", hostname, ":", port,
+            " already exists, updating weight ",
+            host.nodeWeight, "-> ",nodeWeight)
+
+    if host.nodeWeight ~= nodeWeight then
+      -- weight changed, go update
+      local dirty = host:change(nodeWeight)
+      if dirty then
+        -- update had an impact so must redistribute indices
+        self:afterHostUpdate(host)
+      end
+    end
+  end
+
+  return self
+end
+
+
+--- This method is called after a host is being removed from the balancer.
+--
+--  When implementing a new balancer algorithm, you might want to override this method.
+--
+-- The call is after disabling, but before deleting the associated addresses. The
+-- address.disabled field will be true for addresses that are about to be deleted.
+-- @param host the `host` object about to be deleted
+function objBalancer:beforeHostDelete(host)
+end
+
+
+--- This method is called after an address is being added to the balancer.
+--
+-- When implementing a new balancer algorithm, you might want to override this method.
+function objBalancer:onAddAddress(address)
+  local list = self.addresses
+  assert(list[address] == nil, "Can't add address twice")
+
+  list[#list + 1] = address
+end
+
+
+--- This method is called after an address has been deleted from the balancer.
+--
+-- When implementing a new balancer algorithm, you might want to override this method.
+function objBalancer:onRemoveAddress(address)
+  local list = self.addresses
+
+  -- go remove it
+  for i, addr in ipairs(list) do
+    if addr == address then
+      -- found it
+      table_remove(list, i)
+      return
+    end
+  end
+  error("Address not in the list")
+end
+
+--- Removes a host from the balancer. All associated addresses will be
+-- deleted, causing updates to the balancer algorithm.
+-- Will not throw an error if the hostname is not in the current list.
+-- @param hostname hostname to remove
+-- @param port port to remove (optional, defaults to 80 if omitted)
+-- @return balancer object, or an error on bad input
+-- @within User properties
+function objBalancer:removeHost(hostname, port)
+  assert(type(hostname) == "string", "expected a hostname (string), got "..tostring(hostname))
+  port = port or DEFAULT_PORT
+  for i, host in ipairs(self.hosts) do
+    if host.hostname == hostname and host.port == port then
+
+      ngx_log(ngx_DEBUG, self.log_prefix, "removing host ", hostname, ":", port)
+
+      -- set weights to 0
+      host:disable()
+
+      -- removing hosts must always be recalculated to make sure
+      -- its order is deterministic (only dns updates are not)
+      self:beforeHostDelete(host)
+
+      -- remove host
+      host:delete()
+      table_remove(self.hosts, i)
+      break
+    end
+  end
+  return self
+end
+
+-- Updates the total weight.
+-- @param delta the in/decrease of the overall weight (negative for decrease)
+function objBalancer:addWeight(delta)
+  self.weight = self.weight + delta
+end
+
+
+--- Gets the next ip address and port according to the loadbalancing scheme.
+-- If the dns record attached to the requested wheel index is expired, then it will
+-- be renewed and as a consequence the balancer algorithm might be updated.
+-- @param hashValue (optional) number for consistent hashing, round-robins if
+-- omitted. The hashValue must be an (evenly distributed) `integer >= 0`.
+-- @param retryCount should be 0 (or `nil`) on the initial try, 1 on the first
+-- retry, etc.
+-- @param cacheOnly If truthy, no dns lookups will be done, only cache.
+-- @return `ip + port + hostname`, or `nil+error`
+-- @within User properties
+function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
+
+  error(("Not implemented. hashValue: %s retryCount: %s cacheOnly: %s"):format(
+      tostring(hashValue), tostring(retryCount), tostring(cacheOnly)))
+
+
+  -- below is just some example code:
+
+
+  local address
+  while true do
+    if self.weight == 0 then
+      -- the balancer weight is 0, so we have no targets at all.
+      -- This check must be inside the loop, since caling getPeer could
+      -- cause a DNS update.
+      return nil, errors.ERR_NO_PEERS_AVAILABLE
+    end
+
+
+    -- go and find the next `address` object according to the LB policy
+    address = nil
+
+
+    local ip, port, hostname = address:getPeer(cacheOnly)
+    if ip then
+      -- success, exit
+      return ip, port, hostname
+
+    elseif port == errors.ERR_ADDRESS_UNAVAILABLE then
+      -- the address was marked as unavailable, keep track here
+      -- if all of them fail, then do:
+      return nil, errors.ERR_NO_PEERS_AVAILABLE
+
+    elseif port ~= errors.ERR_DNS_UPDATED then
+      -- an unknown error
+      return nil, port
+    end
+
+    -- if here, we're going to retry because of an unavailable
+    -- peer, or because of a dns update
+  end
+
+end
+
+
+--- Sets the current status of an address.
+-- This allows to temporarily suspend peers when they are offline/unhealthy,
+-- it will not modify the address held by the record. The parameters passed in should
+-- be previous results from `getPeer`.
+-- @param available `true` for enabled/healthy, `false` for disabled/unhealthy
+-- @param ip ip address of the peer
+-- @param port the port of the peer (in address object, not as recorded with the Host!)
+-- @param hostname (optional, defaults to the value of `ip`) the hostname
+-- @return `true` on success, or `nil+err` if not found
+-- @within User properties
+function objBalancer:setPeerStatus(available, ip, port, hostname)
+  hostname = hostname or ip
+  local name_srv = {}
+  for _, addr, host in self:addressIter() do
+    if host.hostname == hostname and addr.port == port then
+      if addr.ip == ip then
+        -- found it
+        addr:setState(available)
+        return true
+      elseif addr.ipType == "name" then
+        -- so.... the ip is a name. This means that the host that
+        -- was added most likely resolved to an SRV, which then has
+        -- in turn names as targets instead of ip addresses.
+        -- (possibly a fake SRV for ttl=0 records)
+        -- Those names are resolved last minute by `getPeer`.
+        -- TLDR: we don't track the IP in this case, so we cannot match the
+        -- inputs back to an address to disable/enable it.
+        -- We record this fact here, and if we have no match in the end
+        -- we can provide a more specific message
+        name_srv[#name_srv + 1] = addr.ip .. ":" .. addr.port
+      end
+    end
+  end
+  local msg = ("no peer found by name '%s' and address %s:%s"):format(hostname, ip, tostring(port))
+  if name_srv[1] then
+    -- no match, but we did find a named one, so making the message more explicit
+    msg = msg .. ", possibly the IP originated from these nested dns names: " ..
+          table_concat(name_srv, ",")
+    ngx_log(ngx_WARN, self.log_prefix, msg)
+  end
+  return nil, msg
+end
+
+-- Timer invoked to check for failed queries
+function objBalancer:requeryTimerCallback()
+
+  ngx_log(ngx_DEBUG, self.log_prefix, "executing requery timer")
+
+  local all_ok = true
+  for _, host in ipairs(self.hosts) do
+    -- only retry the errorred ones
+    if host.lastQuery.__errorQueryFlag then
+      all_ok = false -- note: only if NO requery at all is done, we are 'all_ok'
+      -- if even a single dns query is performed, we yield on the dns socket
+      -- operation and our universe might have changed. Could lead to nasty
+      -- race-conditions otherwise.
+      host:queryDns(false) -- timer-context; cacheOnly always false
+    end
+  end
+
+  if all_ok then
+    -- shutdown recurring timer
+    ngx_log(ngx_DEBUG, self.log_prefix, "requery success, stopping timer")
+    self.requeryTimer:cancel()
+    self.requeryTimer = nil
+  else
+    -- not done yet
+    ngx_log(ngx_DEBUG, self.log_prefix, "requery failure")
+  end
+end
+
+-- Starts the requery timer.
+function objBalancer:startRequery()
+  if self.requeryTimer then return end  -- already running, nothing to do here
+
+  local err
+  self.requeryTimer, err = resty_timer({
+      recurring = true,
+      interval = self.requeryInterval,
+      detached = false,
+      expire = self.requeryTimerCallback,
+    }, self)
+
+  if not self.requeryTimer then
+    ngx_log(ngx_ERR, self.log_prefix, "failed to create the timer: ", err)
+  end
+end
+
+--- Sets an event callback for user code. The callback is invoked for
+-- every address added to/removed from the balancer.
+-- Signature of the callback is:
+--
+--   `function(balancer, action, ip, port, hostname)`
+--
+-- where `ip` might also
+-- be a hostname if the DNS resolution returns another name (usually in
+-- SRV records). The `action` parameter will be either `"added"` or `"removed"`.
+-- @param callback a function called when an address is added/removed
+-- @return `true`, or throws an error on bad input
+-- @within User properties
+function objBalancer:setCallback(callback)
+  assert(type(callback) == "function", "expected a callback function")
+  self.callback = callback
+  return true
+end
+
+--- Creates a new base balancer.
+--
+-- A single balancer can hold multiple hosts. A host can be an ip address or a
+-- name. As such each host can have multiple addresses (or actual ip+port
+-- combinations).
+--
+-- The options table has the following fields;
+--
+-- - `dns` (required) a configured `dns.client` object for querying the dns server.
+-- - `requery` (optional) interval of requerying the dns server for previously
+-- failed queries. Defaults to 30 if omitted (in seconds)
+-- - `ttl0` (optional) Maximum lifetime for records inserted with `ttl=0`, to verify
+-- the ttl is still 0. Defaults to 60 if omitted (in seconds)
+-- - `callback` (optional) a function called when an address is added. See
+-- `setCallback` for details.
+-- - `log_prefix` (optional) a name used in the prefix for log messages. Defaults to
+-- `"balancer"` which results in log prefix `"[balancer 1]"` (the number is a sequential
+-- id number)
+-- @param opts table with options
+-- @return new balancer object or nil+error
+-- @within User properties
+_M.new = function(opts)
+  assert(type(opts) == "table", "Expected an options table, but got: "..type(opts))
+  assert(opts.dns, "expected option `dns` to be a configured dns client")
+  assert((opts.requery or 1) > 0, "expected 'requery' parameter to be > 0")
+  assert((opts.ttl0 or 1) > 0, "expected 'ttl0' parameter to be > 0")
+  assert(type(opts.callback) == "function" or type(opts.callback) == "nil",
+    "expected 'callback' to be a function or nil, but got: " .. type(opts.callback))
+
+  balancer_id_counter = balancer_id_counter + 1
+  local self = {
+    -- properties
+    log_prefix = "[" .. (opts.log_prefix or "balancer") .. " " .. tostring(balancer_id_counter) .. "] ",
+    hosts = {},    -- a list a host objects
+    addresses = {}, -- a list of addresses, including reverse lookup
+    weight = 0,    -- total weight of all hosts
+    dns = opts.dns,  -- the configured dns client to use for resolving
+    requeryTimer = nil,  -- requery timer is not running, see `startRequery`
+    requeryInterval = opts.requery or REQUERY_INTERVAL,  -- how often to requery failed dns lookups (seconds)
+    ttl0Interval = opts.ttl0 or TTL_0_RETRY, -- refreshing ttl=0 records
+    callback = opts.callback or function() end, -- callback for address mutations
+  }
+  self = setmetatable(self, mt_objBalancer)
+  self.super = objBalancer
+
+  ngx_log(ngx_DEBUG, self.log_prefix, "balancer_base created")
+  return self
+end
+
+-- export the error constants
+_M.errors = errors
+objBalancer.errors = errors
+
+return _M


### PR DESCRIPTION
A lot of the code in the balancer is DNS related, fanning out hosts
to underlying addresses and tracking them over DNS updates.
This disentangles them, such that the DNS related code now becomes
a base class that can be used to build balancers on top. The ring
balancer just being one of them.

Todo:

- [x] disentangle code
- [x] validate test suite
- [x] update documentation/comments
