### PR TITLE
fix(balancer) introduce a handle to set peer status

### DIFF
--- a/spec/handle_spec.lua
+++ b/spec/handle_spec.lua
@@ -1,0 +1,112 @@
+local spy = require "luassert.spy"
+
+
+describe("[handle]", function()
+
+
+  local handle
+
+  before_each(function()
+    handle = require "resty.dns.handle"
+  end)
+
+
+
+  it("returning doesn't trigger __gc", function()
+    local s = spy.new(function() end)
+    local h = handle.get(s)
+    handle.release(h)
+    h = nil
+    collectgarbage()
+    collectgarbage()
+    assert.spy(s).was_not.called()
+  end)
+
+
+  it("not returning triggers __gc", function()
+    local s = spy.new(function() end)
+    local h = handle.get(s)
+    h = nil
+    collectgarbage()
+    collectgarbage()
+    assert.spy(s).was.called()
+  end)
+
+
+  it("not returning doesn't fail without __gc", function()
+    local h = handle.get()  -- no __gc provided
+    h = nil
+    collectgarbage()
+    collectgarbage()
+  end)
+
+
+  it("handles get re-used", function()
+    local h = handle.get()
+    local id = tostring(h)
+    handle.release(h)
+    h = handle.get()
+    assert.equal(id, tostring(h))
+  end)
+
+
+  it("handles get cleared before re-use", function()
+    local h = handle.get()
+    local id = tostring(h)
+    h.hello = "world"
+    handle.release(h)
+    h = handle.get()
+
+    assert.equal(id, tostring(h))
+    assert.is_nil(h.hello)
+  end)
+
+
+  it("beyond cache-size, handles are dropped", function()
+    handle.setCacheSize(1)
+    local h1 = handle.get()
+    local h2 = handle.get()
+    local id1 = tostring(h1)
+    local id2 = tostring(h2)
+    handle.release(h1)
+    handle.release(h2)
+    h1 = handle.get()
+    h2 = handle.get()
+    assert.equal(id1, tostring(h1))
+    assert.not_equal(id2, tostring(h2))
+  end)
+
+
+  it("__gc is not invoked when handle beyond cache size is dropped", function()
+    handle.setCacheSize(1)
+    local s = spy.new(function() end)
+    local h1 = handle.get(s)
+    local h2 = handle.get(s)
+    local id1 = tostring(h1)
+    local id2 = tostring(h2)
+    handle.release(h1)  -- returned to cache
+    handle.release(h2)  -- dropped
+    h1 = nil
+    h2 = nil
+    collectgarbage()
+    collectgarbage()
+    assert.spy(s).was_not.called()
+  end)
+
+
+  it("reducing cache-size drops whatever is too many", function()
+    handle.setCacheSize(2)
+    local h1 = handle.get()
+    local h2 = handle.get()
+    local id1 = tostring(h1)
+    local id2 = tostring(h2)
+    handle.release(h1)  -- returned to cache
+    handle.release(h2)  -- returned to cache
+    handle.setCacheSize(1)  -- the last one is now dropped
+    h1 = handle.get()
+    h2 = handle.get()
+    assert.equal(id1, tostring(h1))
+    assert.not_equal(id2, tostring(h2))
+  end)
+
+end)

--- a/src/resty/dns/balancer.lua
+++ b/src/resty/dns/balancer.lua
@@ -293,12 +293,12 @@ function ring_balancer:getPeer(cacheOnly, handle, hashValue)
       hashValue = handle.hashValue  -- reuse existing (if any) hashvalue
     end
     handle.retryCount = handle.retryCount + 1
+    --handle.address:release(handle, true)  -- not needed, nothing to release
   else
     -- no handle, so this is a first try
-    handle = {
-      retryCount = 0,
-      hashValue = hashValue,
-    }
+    handle = self:getHandle()  -- no GC specific handler needed
+    handle.retryCount = 0
+    handle.hashValue = hashValue
   end
 
   -- calculate starting point

--- a/src/resty/dns/balancer_base.lua
+++ b/src/resty/dns/balancer_base.lua
@@ -839,21 +839,37 @@ end
 --- Gets the next ip address and port according to the loadbalancing scheme.
 -- If the dns record attached to the requested wheel index is expired, then it will
 -- be renewed and as a consequence the balancer algorithm might be updated.
+-- @param cacheOnly If truthy, no dns lookups will be done, only cache.
+-- @param handle the `handle` returned by a previous call to `getPeer`. This will
+-- retain some state over retries. See also `setPeerStatus`.
 -- @param hashValue (optional) number for consistent hashing, round-robins if
 -- omitted. The hashValue must be an (evenly distributed) `integer >= 0`.
--- @param retryCount should be 0 (or `nil`) on the initial try, 1 on the first
--- retry, etc.
--- @param cacheOnly If truthy, no dns lookups will be done, only cache.
--- @return `ip + port + hostname`, or `nil+error`
+-- @return `ip + port + hostname` + `handle`, or `nil+error`
 -- @within User properties
-function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
+function objBalancer:getPeer(cacheOnly, handle, hashValue)
 
-  error(("Not implemented. hashValue: %s retryCount: %s cacheOnly: %s"):format(
-      tostring(hashValue), tostring(retryCount), tostring(cacheOnly)))
+  error(("Not implemented. cacheOnly: %s hashValue: %s"):format(
+      tostring(cacheOnly), tostring(hashValue)))
 
 
-  -- below is just some example code:
+  --[[ below is just some example code:
 
+  if handle then
+    -- existing handle, so it's a retry
+    if hashValue then
+      -- we have a new hashValue, use it anyway
+      handle.hashValue = hashValue
+    else
+      hashValue = handle.hashValue  -- reuse exiting (if any) hashvalue
+    end
+    handle.retryCount = handle.retryCount + 1
+  else
+    -- no handle, so this is a first try
+    handle = {
+      retryCount = 0,
+      hashValue = hashValue,
+    }
+  end
 
   local address
   while true do
@@ -872,7 +888,8 @@ function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
     local ip, port, hostname = address:getPeer(cacheOnly)
     if ip then
       -- success, exit
-      return ip, port, hostname
+      handle.address = address
+      return ip, port, hostname, handle
 
     elseif port == errors.ERR_ADDRESS_UNAVAILABLE then
       -- the address was marked as unavailable, keep track here
@@ -888,6 +905,7 @@ function objBalancer:getPeer(hashValue, retryCount, cacheOnly)
     -- peer, or because of a dns update
   end
 
+  -- unreachable   --]]
 end
 
 
@@ -895,18 +913,29 @@ end
 -- This allows to temporarily suspend peers when they are offline/unhealthy,
 -- it will not modify the address held by the record. The parameters passed in should
 -- be previous results from `getPeer`.
+-- Call this either as `setPeerStatus(available, handle)` or as `setPeerStatus(available, ip, port, <hostname>)`.
+-- Using the `handle` is preferred since it is guaranteed to match an address. By ip/port/name
+-- might fail if there are too many DNS levels.
 -- @param available `true` for enabled/healthy, `false` for disabled/unhealthy
--- @param ip ip address of the peer
+-- @param ip_or_handle ip address of the peer, or the `handle` returned by `getPeer`
 -- @param port the port of the peer (in address object, not as recorded with the Host!)
 -- @param hostname (optional, defaults to the value of `ip`) the hostname
 -- @return `true` on success, or `nil+err` if not found
 -- @within User properties
-function objBalancer:setPeerStatus(available, ip, port, hostname)
-  hostname = hostname or ip
+function objBalancer:setPeerStatus(available, ip_or_handle, port, hostname)
+
+  if type(ip_or_handle) == "table" then
+    -- it's a handle from `setPeer`.
+    ip_or_handle.address:setState(available)
+    return true
+  end
+
+  -- no handle, so go and search for it
+  hostname = hostname or ip_or_handle
   local name_srv = {}
   for _, addr, host in self:addressIter() do
     if host.hostname == hostname and addr.port == port then
-      if addr.ip == ip then
+      if addr.ip == ip_or_handle then
         -- found it
         addr:setState(available)
         return true
@@ -924,7 +953,7 @@ function objBalancer:setPeerStatus(available, ip, port, hostname)
       end
     end
   end
-  local msg = ("no peer found by name '%s' and address %s:%s"):format(hostname, ip, tostring(port))
+  local msg = ("no peer found by name '%s' and address %s:%s"):format(hostname, ip_or_handle, tostring(port))
   if name_srv[1] then
     -- no match, but we did find a named one, so making the message more explicit
     msg = msg .. ", possibly the IP originated from these nested dns names: " ..

--- a/src/resty/dns/handle.lua
+++ b/src/resty/dns/handle.lua
@@ -1,0 +1,146 @@
+---
+-- Handle module.
+--
+-- Implements handles to be used by the `objBalancer:getPeer` method. These
+-- implement a __gc method for tracking statistics and not leaking resources
+-- in case a connection gets aborted prematurely.
+--
+-- This module is only relevant when implementing your own balancer
+-- algorithms.
+--
+-- @author Thijs Schreijer
+-- @copyright 2016-2018 Kong Inc. All rights reserved.
+-- @license Apache 2.0
+
+
+local table_new = require "table.new"
+local table_clear = require "table.clear"
+local empty = {}
+
+
+local cache_max = 1000
+local cache_count = 0
+local cache = table_new(cache_max, 0)
+
+
+local _M = {}
+
+
+local createHandle
+do
+  local function udata_gc_method(self)
+    -- find our handle
+    local mt = getmetatable(self)
+    local handle = mt.handle
+    -- disconnect handle and udata
+    mt.handle = nil
+    handle.__udata = nil
+    -- find __gc method
+    local __gc = (handle or empty).__gc
+    if not __gc then
+      return
+    end
+    -- execute __gc method
+    __gc(handle)
+  end
+
+  function createHandle(__gc)
+    -- create handle
+    local handle = {
+      __gc = __gc
+    }
+    -- create userdata
+    local __udata = newproxy(true)
+    local mt = getmetatable(__udata)
+    mt.__gc = udata_gc_method
+    -- connect handle and userdata
+    mt.handle = handle
+    handle.__udata = __udata
+
+    return handle
+  end
+end
+
+--- Gets a handle from the cache.
+-- The handle comes from the cache or it is newly created. A handle is just a
+-- table. It will have two special fields:
+--
+-- - `__udata`: (read-only) a userdata used to track the lifetime of the handle
+-- - `__gc`: (read/write) this method will be called on GC.
+--
+-- __NOTE__: the `__gc` will only be called when the handle is garbage collected,
+-- not when it is returned by calling `release`.
+-- @param __gc (optional, function) the method called when the handle is GC'ed.
+-- @return handle
+-- @usage
+-- local handle = _M
+--
+-- local my_gc_handler = function(self)
+--   print(self.name .. " was deleted")
+-- end
+--
+-- local h1 = handle.get(my_gc_handler)
+-- h1.name = "Obama"
+-- local h2 = handle.get(my_gc_handler)
+-- h2.name = "Trump"
+--
+-- handle.release(h1)   -- explicitly release it
+-- h1 = nil
+-- h2 = nil             -- not released, will be GC'ed
+-- collectgarbage()
+-- collectgarbage()     --> "Trump was deleted"
+function _M.get(__gc)
+  if cache_count == 0 then
+    -- cache is empty, create a new one
+    return createHandle(__gc)
+  end
+  local handle = cache[cache_count]
+  cache[cache_count] = nil
+  cache_count = cache_count - 1
+  handle.__gc = __gc
+  return handle
+end
+
+--- Returns a handle to the cache.
+-- The handle will be cleared, returned to the cache, and its `__gc` handle
+-- will NOT be called.
+-- @param handle the handle to return to the cache
+-- @return nothing
+function _M.release(handle)
+  local __udata = handle.__udata
+  if not __udata then
+    -- this one was GC'ed, we check this because we do not want
+    -- to accidentally ressurect a handle.
+    return
+  end
+  if cache_count >= cache_max then
+    -- we're dropping this one, our cache is full
+    handle.__udata = nil
+    handle.__gc = nil
+    return
+  end
+  -- return it to the cache
+  table_clear(handle)
+  handle.__udata = __udata
+  cache_count = cache_count + 1
+  cache[cache_count] = handle
+end
+
+
+--- Sets a new cache size. The default size is 1000.
+-- @param size the new size.
+-- @return nothing, or throws an error on bad input
+function _M.setCacheSize(size)
+  assert(type(size) == "number", "expected a number")
+  assert(size >= 0, "expected size >= 0")
+  cache_max = size
+  local new_cache = table_new(cache_max, 0)
+  cache_count = math.min(cache_count, size)
+  for i = 1, cache_count do
+    new_cache[i] = cache[i]
+  end
+  cache = new_cache
+end
+
+
+return _M


### PR DESCRIPTION
Setting status wasn't always possible, if an address still contained a name instead of an ip (SRV -> A -> ip).
By returning a handle, the proper reference is preserved, and as a side effect the `retryCount` parameter is now obsolete.

Signature of `getPeer` changed, and hence this is a breaking change

NOTE: this is not against `master`, but `split-balancer` to avoid too many conflicts