### PR TITLE
fix(client) log failure to create a timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ History
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
+### #.0.x (x-xx-2019)
+
+- Fix: when an asyncquery failed to create the timer, it would silently ignore
+  the error. Error is now being logged.
+
 ### 3.0.2 (8-Mar-2019) Bugfix
 
 - Fix: callback for adding an address did not pass the address object, but

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -28,6 +28,7 @@ local resolver = require("resty.dns.resolver")
 local deepcopy = require("pl.tablex").deepcopy
 local time = ngx.now
 local log = ngx.log
+local ERR = ngx.ERR
 local WARN = ngx.WARN
 local DEBUG = ngx.DEBUG
 local PREFIX = "[dns-client] "
@@ -755,6 +756,7 @@ local function asyncQuery(qname, r_opts, try_list)
   local ok, err = timer_at(0, executeQuery, item)
   if not ok then
     queue[key] = nil
+    log(ERR, PREFIX, "Failed to create a timer: ", err)
     return nil, "asyncQuery failed to create timer: "..err
   end
   --[[


### PR DESCRIPTION
The error was returned, but not all callers would properly check
the results. Hence log it where it happens.