### PR TITLE
fix(balancer) recover after dns updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ History
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
+### 4.1.0 (unreleased)
+
+- Fix: unhelthy balancers would not recover because they would not refresh the
+  DNS records used. See [PR 73](https://github.com/Kong/lua-resty-dns-client/pull/73).
+- Added: automatic background resolving of hostnames, expiry will be checked
+  every second, and if needed DNS (and balancer) will be updated. See [PR 73](https://github.com/Kong/lua-resty-dns-client/pull/73).
+
 ### 4.0.0 (26-Jun-2019)
 
 - BREAKING: the balancer callback is called with a new event; "health" whenever

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
 ### 4.1.0 (unreleased)
 
-- Fix: unhelthy balancers would not recover because they would not refresh the
+- Fix: unhealthy balancers would not recover because they would not refresh the
   DNS records used. See [PR 73](https://github.com/Kong/lua-resty-dns-client/pull/73).
 - Added: automatic background resolving of hostnames, expiry will be checked
   every second, and if needed DNS (and balancer) will be updated. See [PR 73](https://github.com/Kong/lua-resty-dns-client/pull/73).

--- a/spec/balancer/base_spec.lua
+++ b/spec/balancer/base_spec.lua
@@ -17,7 +17,6 @@ describe("[balancer_base]", function()
 
   setup(function()
     _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
-    _G._TEST = true  -- expose internals for test purposes
     balancer_base = require "resty.dns.balancer.base"
     client = require "resty.dns.client"
   end)

--- a/spec/balancer/generic_spec.lua
+++ b/spec/balancer/generic_spec.lua
@@ -14,7 +14,6 @@ for algorithm, balancer_module in helpers.balancer_types() do
 
     setup(function()
       _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
-      _G._TEST = true  -- expose internals for test purposes
       client = require "resty.dns.client"
     end)
 

--- a/spec/balancer/least_connections_spec.lua
+++ b/spec/balancer/least_connections_spec.lua
@@ -70,7 +70,6 @@ describe("[least-connections]", function()
 
   setup(function()
     _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
-    _G._TEST = true  -- expose internals for test purposes
     lcb = require "resty.dns.balancer.least_connections"
     client = require "resty.dns.client"
   end)

--- a/spec/balancer/ring_spec.lua
+++ b/spec/balancer/ring_spec.lua
@@ -111,7 +111,6 @@ describe("[ringbalancer]", function()
 
   setup(function()
     _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
-    _G._TEST = true  -- expose internals for test purposes
     balancer = require "resty.dns.balancer.ring"
     client = require "resty.dns.client"
   end)

--- a/spec/client_cache_spec.lua
+++ b/spec/client_cache_spec.lua
@@ -20,7 +20,6 @@ describe("[DNS client cache]", function()
   local client, resolver, query_func
 
   before_each(function()
-    _G._TEST = true
     client = require("resty.dns.client")
     resolver = require("resty.dns.resolver")
 
@@ -54,7 +53,6 @@ describe("[DNS client cache]", function()
     client = nil
     resolver = nil
     query_func = nil
-    _G._TEST = nil
   end)
 
 

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -30,7 +30,6 @@ describe("[DNS client]", function()
   local client, resolver, query_func
 
   before_each(function()
-    _G._TEST = true
     client = require("resty.dns.client")
     resolver = require("resty.dns.resolver")
 
@@ -63,7 +62,6 @@ describe("[DNS client]", function()
     client = nil
     resolver = nil
     query_func = nil
-    _G._TEST = nil
   end)
 
   describe("initialization", function()

--- a/src/resty/dns/balancer/least_connections.lua
+++ b/src/resty/dns/balancer/least_connections.lua
@@ -214,7 +214,7 @@ function _M.new(opts)
     opts.log_prefix = "least-connections"
   end
 
-  local self = balancer_base.new(opts)
+  local self = assert(balancer_base.new(opts))
 
   -- inject overridden methods
   for name, method in pairs(lc) do

--- a/src/resty/dns/balancer/ring.lua
+++ b/src/resty/dns/balancer/ring.lua
@@ -429,7 +429,7 @@ function _M.new(opts)
     opts.log_prefix = "ringbalancer"
   end
 
-  local self = balancer_base.new(opts)
+  local self = assert(balancer_base.new(opts))
 
   if (not opts.wheelSize) and opts.order then
     opts.wheelSize = #opts.order

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -1507,7 +1507,7 @@ _M.connect = connect
 _M.setpeername = setpeername
 
 -- export the locals in case we're testing
-if _TEST then    -- luacheck: ignore
+if package.loaded.busted then
   _M.getcache = function() return dnscache end
   _M._search_iter = search_iter -- export as different name!
 end


### PR DESCRIPTION
Since the health was introduced on the balancer, there is an early
exit if the balancer is unhealthy. This introduced a problem where
DNS record would remain untouched, and hence would not be refreshed.
Leaving the balancer in an unhealthy state forever.

issue: https://github.com/Kong/kong/issues/4781