### PR TITLE
fix(logging) reduce noise of the requery timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 ### 4.1.x (xxxx) unreleased
 
 - Fix: added logging of try-list to the TCP/UDP wrappers, see [PR 75](https://github.com/Kong/lua-resty-dns-client/pull/75).
+- Fix: reduce logging noise of the requery timer
 
 ### 4.1.0 (7-Aug-2019)
 

--- a/src/resty/dns/balancer/base.lua
+++ b/src/resty/dns/balancer/base.lua
@@ -1199,16 +1199,13 @@ function objBalancer:resolveTimerCallback()
   --including those with errors
   --we update, so changes on the list while traversing can happen, keep track of that
 
-  ngx_log(ngx_DEBUG, self.log_prefix, "executing requery timer")
-
   for _, host in ipairs(self.hosts) do
     -- only retry the errorred ones
     if (host.lastQuery.expire or 0) < time() then
+      ngx_log(ngx_DEBUG, self.log_prefix, "executing requery for: ", host.hostname)
       host:queryDns(false) -- timer-context; cacheOnly always false
     end
   end
-
-  ngx_log(ngx_DEBUG, self.log_prefix, "requery completed")
 end
 
 


### PR DESCRIPTION
instead of logging each start and end (every second), now only
log when a host is actually being requeried.