### PR TITLE
fix(base) avoid a crash when self.lastQuery is not set

### DIFF
--- a/src/resty/dns/balancer/base.lua
+++ b/src/resty/dns/balancer/base.lua
@@ -699,7 +699,7 @@ end
 
 function objHost:addressStillValid(cacheOnly, address)
 
-  if (self.lastQuery.expire or 0) < time() and not cacheOnly then
+  if ((self.lastQuery or empty).expire or 0) < time() and not cacheOnly then
     -- ttl expired, so must renew
     self:queryDns(cacheOnly)
 


### PR DESCRIPTION
I cannot reproduce this easily, but I've had a crash in the logs
caused by attempting to dereference `self.lastQuery.expire` when
`self.lastQuery` was `nil`.

Patched it like this to match the coding style present in this
module.