### PR TITLE
fix(balancer) fix ttl-0 records issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ History
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 
+### 4.1.x (xx-xxx-2020)
+
+- Fix: fix ttl-0 records issues with the balancer, see Kong issue
+  https://github.com/Kong/kong/issues/5477
+  * the previous record was not properly detected as a ttl=0 record
+    by checking on the `__ttl0flag` we now do
+  * since the "fake" SRV record wasn't updated with a new expiry
+    time the expiry-check-timer would keep updating that record
+    every second
+
 ### 4.1.2 (10-Dec-2019)
 
 - Fix: handle cases when `lastQuery` is `nil`, see [PR 81](https://github.com/Kong/lua-resty-dns-client/pull/81)

--- a/src/resty/dns/balancer/base.lua
+++ b/src/resty/dns/balancer/base.lua
@@ -413,7 +413,8 @@ local function update_dns_result(self, newQuery, dns)
   -- So if we get a ttl=0 twice in a row (the old one, and the new one), we update it. And
   -- if the very first request ever reports ttl=0 (we assume we're not hitting the edgecase
   -- in that case)
-  if (newQuery[1] or empty).ttl == 0 and ((oldQuery[1] or empty).ttl or 0) == 0 then
+  if (newQuery[1] or empty).ttl == 0 and
+     (((oldQuery[1] or empty).ttl or 0) == 0 or oldQuery.__ttl0Flag) then
     -- ttl = 0 means we need to lookup on every request.
     -- To enable lookup on each request we 'abuse' a virtual SRV record. We set the ttl
     -- to `ttl0Interval` seconds, and set the `target` field to the hostname that needs
@@ -424,6 +425,8 @@ local function update_dns_result(self, newQuery, dns)
     -- so we fix them at the `nodeWeight` property, as with A and AAAA records.
     if oldQuery.__ttl0Flag then
       -- still ttl 0 so nothing changed
+      oldQuery.touched = time()
+      oldQuery.expire = oldQuery.touched + self.balancer.ttl0Interval
       ngx_log(ngx_DEBUG, self.log_prefix, "no dns changes detected for ",
               self.hostname, ", still using ttl=0")
       return true

--- a/src/resty/dns/balancer/handle.lua
+++ b/src/resty/dns/balancer/handle.lua
@@ -15,7 +15,8 @@
 
 local table_new = require "table.new"
 local table_clear = require "table.clear"
-local empty = {}
+local EMPTY = setmetatable({},
+  {__newindex = function() error("The 'EMPTY' table is read-only") end})
 
 
 local cache_max = 1000
@@ -36,7 +37,7 @@ do
     mt.handle = nil
     handle.__udata = nil
     -- find __gc method
-    local __gc = (handle or empty).__gc
+    local __gc = (handle or EMPTY).__gc
     if not __gc then
       return
     end

--- a/src/resty/dns/balancer/least_connections.lua
+++ b/src/resty/dns/balancer/least_connections.lua
@@ -19,8 +19,8 @@ local binaryHeap = require "binaryheap"
 local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
 
-local empty = setmetatable({},
-  {__newindex = function() error("The 'empty' table is read-only") end})
+local EMPTY = setmetatable({},
+  {__newindex = function() error("The 'EMPTY' table is read-only") end})
 
 local _M = {}
 local lc = {}
@@ -36,7 +36,7 @@ function lcAddr:updateConnectionCount(delta)
   end
 
   -- go update the heap position
-  local bh = ((self.host or empty).balancer or empty).binaryHeap
+  local bh = ((self.host or EMPTY).balancer or EMPTY).binaryHeap
   if bh then
     -- NOTE: we use `connectionCount + 1` this ensures that even on a balancer
     -- with 0 connections the heighest weighted entry is picked first. If we'd
@@ -135,7 +135,7 @@ function lc:getPeer(cacheOnly, handle, hashValue)
           self.binaryHeap:pop()
         end
         address = self.binaryHeap:peek()
-      until address == nil or not (handle.failedAddresses or empty)[address]
+      until address == nil or not (handle.failedAddresses or EMPTY)[address]
 
       if address == nil and handle.failedAddresses then
         -- we failed all addresses, so drop the list of failed ones, we are trying
@@ -225,7 +225,7 @@ function _M.new(opts)
   self.binaryHeap = binaryHeap.minUnique() -- binaryheap tracking next up address
 
   -- add the hosts provided
-  for _, host in ipairs(opts.hosts or empty) do
+  for _, host in ipairs(opts.hosts or EMPTY) do
     if type(host) ~= "table" then
       host = { name = host }
     end

--- a/src/resty/dns/balancer/ring.lua
+++ b/src/resty/dns/balancer/ring.lua
@@ -46,8 +46,8 @@ local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
 local ngx_WARN = ngx.WARN
 
-local empty = setmetatable({},
-  {__newindex = function() error("The 'empty' table is read-only") end})
+local EMPTY = setmetatable({},
+  {__newindex = function() error("The 'EMPTY' table is read-only") end})
 
 local new_tab
 do
@@ -473,7 +473,7 @@ function _M.new(opts)
 
   -- Sort the hosts, to make order deterministic
   local hosts = {}
-  for i, host in ipairs(opts.hosts or empty) do
+  for i, host in ipairs(opts.hosts or EMPTY) do
     if type(host) == "table" then
       hosts[i] = host
     else

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -43,8 +43,8 @@ local table_insert = table.insert
 local table_concat = table.concat
 local string_lower = string.lower
 
-local empty = setmetatable({},
-  {__newindex = function() error("The 'empty' table is read-only") end})
+local EMPTY = setmetatable({},
+  {__newindex = function() error("The 'EMPTY' table is read-only") end})
 
 -- resolver options
 local config
@@ -183,7 +183,7 @@ local cacheinsert = function(entry, qname, qtype)
 
     elseif entry.errcode and entry.errcode ~= 3 then
       -- an error, but no 'name error' (3)
-      if (cachelookup(qname, qtype) or empty)[1] then
+      if (cachelookup(qname, qtype) or EMPTY)[1] then
         -- we still have a stale record with data, so we're not replacing that
         --[[
         log(DEBUG, PREFIX, "cache set (skip on name error): ", key, " ", frecord(entry))
@@ -200,7 +200,7 @@ local cacheinsert = function(entry, qname, qtype)
 
     else
       -- empty record
-      if (cachelookup(qname, qtype) or empty)[1] then
+      if (cachelookup(qname, qtype) or EMPTY)[1] then
         -- we still have a stale record with data, so we're not replacing that
         --[[
         log(DEBUG, PREFIX, "cache set (skip on empty): ", key, " ", frecord(entry))
@@ -1068,7 +1068,7 @@ end
 -- @return `list of records + nil + try_list`, or `nil + err + try_list`.
 local function resolve(qname, r_opts, dnsCacheOnly, try_list)
   qname = string_lower(qname)
-  local qtype = (r_opts or empty).qtype
+  local qtype = (r_opts or EMPTY).qtype
   local err, records
 
   local opts = {}
@@ -1110,7 +1110,7 @@ local function resolve(qname, r_opts, dnsCacheOnly, try_list)
     else
       -- a valid non-stale record
       -- check for CNAME records, and dereferencing the CNAME
-      if (records[1] or empty).type == _M.TYPE_CNAME and qtype ~= _M.TYPE_CNAME then
+      if (records[1] or EMPTY).type == _M.TYPE_CNAME and qtype ~= _M.TYPE_CNAME then
         opts.qtype = nil
         try_status(try_list, "dereferencing")
         return resolve(records[1].cname, opts, dnsCacheOnly, try_list)


### PR DESCRIPTION
* the previous record was not properly detected as a ttl=0 record
  by checking on the __ttl0flag we now do

* since the "fake" SRV record wasn't updated with a new expiry
  time the expiry-check-timer would keep updating that record
  every second

Fixes Kong issue https://github.com/Kong/kong/issues/5477