### PR TITLE
fix(balancer) use proper dns client

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Release process:
 4. commit and tag the release
 5. upload rock to LuaRocks
 
+### 4.2.x unreleased
+
+- Fix: using the module instance instead of the passed one for dns resolution
+  in the balancer (only affected testing). See [PR 88](https://github.com/Kong/lua-resty-dns-client/pull/88).
+
 ### 4.2.0 (23-Mar-2020)
 
 - Change: export DNS source type on status report. See [PR 86](https://github.com/Kong/lua-resty-dns-client/pull/86).

--- a/src/resty/dns/balancer/base.lua
+++ b/src/resty/dns/balancer/base.lua
@@ -216,7 +216,7 @@ function objAddr:getPeer(cacheOnly)
 
   if self.ipType == "name" then
     -- SRV type record with a named target
-    local ip, port, try_list = dns_client.toip(self.ip, self.port, cacheOnly)
+    local ip, port, try_list = self.host.balancer.dns.toip(self.ip, self.port, cacheOnly)
     if not ip then
       port = tostring(port) .. ". Tried: " .. tostring(try_list)
     end


### PR DESCRIPTION
The balancer was calling `toip` on the dns-client module, instead
of using the dns client passed to it.
Since the module is to be used as a singleton anyway, this did not
affect any real usage. But in testing the cache would not be
properly reset, since there we reload the entire module forcefully.