### PR TITLE
feat(balancer) option to return nested SRV name as hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Release process:
 
 ### 4.2.x unreleased
 
+- BREAKING: `getPeer` now returns the host-header value instead of the hostname
+  that was used to add the address. This is only breaking if a host was added through
+  `addHost` with an ip-address. In that case `getPeer` will no longer return the
+  ip-address as the hostname, but will now return `nil`.
+- Added: option `useSRVname`, if truthy then `getPeer` will return the name as found
+  in the SRV record, instead of the hostname as added to the balancer.
 - Fix: using the module instance instead of the passed one for dns resolution
   in the balancer (only affected testing). See [PR 88](https://github.com/Kong/lua-resty-dns-client/pull/88).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Release process:
 4. commit and tag the release
 5. upload rock to LuaRocks
 
-### 4.2.x unreleased
+### x.x.x unreleased
 
 - BREAKING: `getPeer` now returns the host-header value instead of the hostname
   that was used to add the address. This is only breaking if a host was added through
@@ -59,6 +59,7 @@ Release process:
   ip-address as the hostname, but will now return `nil`.
 - Added: option `useSRVname`, if truthy then `getPeer` will return the name as found
   in the SRV record, instead of the hostname as added to the balancer.
+- Added: callback return an extra parameter; the host-header for the address added/removed.
 - Fix: using the module instance instead of the passed one for dns resolution
   in the balancer (only affected testing). See [PR 88](https://github.com/Kong/lua-resty-dns-client/pull/88).
 

--- a/spec/balancer/base_spec.lua
+++ b/spec/balancer/base_spec.lua
@@ -157,7 +157,7 @@ describe("[balancer_base]", function()
   describe("callbacks", function()
 
     local list
-    local handler = function(balancer, eventname, address, ip, port, hostname)
+    local handler = function(balancer, eventname, address, ip, port, hostname, hostheader)
       assert(({
         added = true,
         removed = true,
@@ -174,7 +174,7 @@ describe("[balancer_base]", function()
         assert.is.equal(address.port, port)
       end
       list[#list + 1] = {
-        balancer, eventname, address, ip, port, hostname,
+        balancer, eventname, address, ip, port, hostname, hostheader,
       }
     end
 
@@ -202,7 +202,8 @@ describe("[balancer_base]", function()
       assert.is.table(list[2][3])
       assert.equal("127.0.0.1", list[2][4])
       assert.equal(80, list[2][5])
-      assert.equal("localhost", list[2][6])
+      assert.equal("localhost", list[2][6]) -- hostname
+      assert.equal("localhost", list[2][7]) -- hostheader
     end)
 
 
@@ -225,7 +226,8 @@ describe("[balancer_base]", function()
       assert.is.table(list[2][3])
       assert.equal("127.0.0.1", list[2][4])
       assert.equal(80, list[2][5])
-      assert.equal("localhost", list[2][6])
+      assert.equal("localhost", list[2][6]) -- hostname
+      assert.equal("localhost", list[2][7]) -- hostheader
 
       b:removeHost("localhost", 80)
       ngx.sleep(0.1)
@@ -240,7 +242,8 @@ describe("[balancer_base]", function()
       assert.equal(list[2][3], list[4][3])  -- same address object as added
       assert.equal("127.0.0.1", list[4][4])
       assert.equal(80, list[4][5])
-      assert.equal("localhost", list[4][6])
+      assert.equal("localhost", list[4][6]) -- hostname
+      assert.equal("localhost", list[4][7]) -- hostheader
     end)
 
   end)

--- a/spec/balancer/generic_spec.lua
+++ b/spec/balancer/generic_spec.lua
@@ -1507,6 +1507,7 @@ for algorithm, balancer_module in helpers.balancer_types() do
         b = balancer_module.new({
           dns = client,
           healthThreshold = 50,
+          useSRVname = false,
         })
       end)
 
@@ -1515,7 +1516,7 @@ for algorithm, balancer_module in helpers.balancer_types() do
       end)
 
 
-      it("returns expected results/types when using SRV", function()
+      it("returns expected results/types when using SRV with IP", function()
         dnsSRV({
           { name = "konghq.com", target = "1.1.1.1", port = 2, weight = 3 },
         })
@@ -1524,6 +1525,40 @@ for algorithm, balancer_module in helpers.balancer_types() do
         assert.equal("1.1.1.1", ip)
         assert.equal(2, port)
         assert.equal("konghq.com", hostname)
+        assert.equal("userdata", type(handle.__udata))
+      end)
+
+
+      it("returns expected results/types when using SRV with name ('useSRVname=false')", function()
+        dnsA({
+          { name = "getkong.org", address = "1.2.3.4" },
+        })
+        dnsSRV({
+          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+        })
+        b:addHost("konghq.com", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer()
+        assert.equal("1.2.3.4", ip)
+        assert.equal(2, port)
+        assert.equal("konghq.com", hostname)
+        assert.equal("userdata", type(handle.__udata))
+      end)
+
+
+      it("returns expected results/types when using SRV with name ('useSRVname=true')", function()
+        b.useSRVname = true -- override setting specified when creating
+
+        dnsA({
+          { name = "getkong.org", address = "1.2.3.4" },
+        })
+        dnsSRV({
+          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+        })
+        b:addHost("konghq.com", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer()
+        assert.equal("1.2.3.4", ip)
+        assert.equal(2, port)
+        assert.equal("getkong.org", hostname)
         assert.equal("userdata", type(handle.__udata))
       end)
 

--- a/spec/balancer/generic_spec.lua
+++ b/spec/balancer/generic_spec.lua
@@ -1581,7 +1581,7 @@ for algorithm, balancer_module in helpers.balancer_types() do
         local ip, port, hostname, handle = b:getPeer()
         assert.equal("4.3.2.1", ip)
         assert.equal(8000, port)
-        assert.equal("4.3.2.1", hostname)
+        assert.equal(nil, hostname)
         assert.equal("userdata", type(handle.__udata))
       end)
 
@@ -1591,7 +1591,7 @@ for algorithm, balancer_module in helpers.balancer_types() do
         local ip, port, hostname, handle = b:getPeer()
         assert.equal("[::1]", ip)
         assert.equal(8000, port)
-        assert.equal("::1", hostname)
+        assert.equal(nil, hostname)
         assert.equal("userdata", type(handle.__udata))
       end)
 


### PR DESCRIPTION
This enables the balancer to return a host-header.

So far the returned "host" was always the name of the host as it was added to the balancer by calling `addHost()`. With this PR there is a change between the Host as added and the host-header to be used on a request.

- `getPeer()` will return the host-header instead of the name. The **_breaking change_** here is that if the name as added is an IP address, then the host-header returned will be `nil`. Otherwise, with all defaults everything will be the same.
- the balancer gets a new option `useSRVname` (`false` by default), which if set, will instruct the returned Host-header to be the name inside an SRV record. If not and SRV record, then it will return the hostname as added to the balancer (as before).
- the callback for adding/removing addresses gets an extra argument; the host-header (because it is additional it will get the hostname, as well as the host-header)

