### PR TITLE
fix hostname and port parsing

### DIFF
--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -363,6 +363,10 @@ options ndots:2
     it("parses valid name address types", function()
       assert.are.same({"somename", nil, "name"}, {dnsutils.parseHostname("somename")})
       assert.are.same({"somename", 123, "name"}, {dnsutils.parseHostname("somename:123")})
+      assert.are.same({"somename456", nil, "name"}, {dnsutils.parseHostname("somename456")})
+      assert.are.same({"somename456", 123, "name"}, {dnsutils.parseHostname("somename456:123")})
+      assert.are.same({"somename456.domain.local789", nil, "name"}, {dnsutils.parseHostname("somename456.domain.local789")})
+      assert.are.same({"somename456.domain.local789", 123, "name"}, {dnsutils.parseHostname("somename456.domain.local789:123")})
     end)
   end)
 

--- a/src/resty/dns/utils.lua
+++ b/src/resty/dns/utils.lua
@@ -321,7 +321,7 @@ end
 -- @return `name/ip` + `port (or nil)` + `type` (one of: `"ipv4"`, `"ipv6"`, or `"name"`)
 _M.parseHostname = function(name)
   local t = _M.hostnameType(name)
-  if t == "ipv4" then
+  if t == "ipv4" or t == "name" then
     local ip, port = name:match("^([^:]+)%:*(%d*)$")
     return ip, tonumber(port), t
   elseif t == "ipv6" then
@@ -331,8 +331,7 @@ _M.parseHostname = function(name)
     end
     return "["..name.."]", nil, t  -- no brackets also means no port
   end
-  local host, port = name:match("^(.-)%:*(%d*)$")
-  return host, tonumber(port), t
+  return nil, nil, nil -- should never happen
 end
 
 return _M


### PR DESCRIPTION
Currently, domains ending with a number (can happen in internal networks) are parsed wrongly - the trailing number is assumed to be a port. The issue only affects "name" hostname types. 

Examples:
```
test-host123 -> host: test-host, port: 123
test-host.local.domain123 -> host: test-host.local.domain, port: 123
```

The PR change reuses the "ipv4" regex for the "name" type, as it's valid for both cases.