### PR TITLE
fix(timers) reduce timers used

### DIFF
--- a/spec/balancer/generic_spec.lua
+++ b/spec/balancer/generic_spec.lua
@@ -1879,9 +1879,6 @@ for algorithm, balancer_module in helpers.balancer_types() do
         -- destroy it
         ngx.sleep(0)  -- without this it fails, why, why, why?
         b = nil       -- luacheck: ignore
-        -- base = require("resty.dns.balancer.base")
-        -- base._renewal_timer:cancel()
-        -- base._renewal_timer = nil
 
         collectgarbage()
         collectgarbage()

--- a/spec/balancer/generic_spec.lua
+++ b/spec/balancer/generic_spec.lua
@@ -1877,7 +1877,6 @@ for algorithm, balancer_module in helpers.balancer_types() do
         assert.not_nil(next(test_table))
 
         -- destroy it
---b:removeHost("127.0.0.1", 8000) -- should not be necessary
         ngx.sleep(0)  -- without this it fails, why, why, why?
         b = nil       -- luacheck: ignore
         -- base = require("resty.dns.balancer.base")


### PR DESCRIPTION
This implementation of timer reduction uses a binary heap to sort the values up for renewal, so the update mechanism does not iterate over all targets in all balancers, but only checks the ones to renew. So this is more efficient.
