### PR TITLE
perf(client) reduce amount of timers on init_worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_store
 *.rock
-
+t/servroot/

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ install:
   - if [ -z "$OPENRESTY_VER" ]; then export OPENRESTY_VER=1.15.8.3; fi
   - if [ ! -f download-cache/openresty-$OPENRESTY_VER.tar.gz ]; then wget -O download-cache/openresty-$OPENRESTY_VER.tar.gz http://openresty.org/download/openresty-$OPENRESTY_VER.tar.gz; fi
   - if [ ! -f download-cache/luarocks-$LUAROCKS_VER.tar.gz ]; then wget -O download-cache/luarocks-$LUAROCKS_VER.tar.gz https://luarocks.github.io/luarocks/releases/luarocks-$LUAROCKS_VER.tar.gz; fi
+  - if [ ! -f download-cache/cpanm ]; then wget -O download-cache/cpanm https://cpanmin.us/; fi
+  - chmod +x download-cache/cpanm
+  - download-cache/cpanm --notest Test::Nginx >build.log 2>&1 || (cat build.log && exit 1)
+  - download-cache/cpanm --notest --local-lib=$TRAVIS_BUILD_DIR/perl5 local::lib && eval $(perl -I $TRAVIS_BUILD_DIR/perl5/lib/perl5/ -Mlocal::lib)
   - tar -zxf download-cache/openresty-$OPENRESTY_VER.tar.gz
   - tar -zxf download-cache/luarocks-$LUAROCKS_VER.tar.gz
   - pushd openresty-$OPENRESTY_VER
@@ -49,3 +53,4 @@ install:
 script:
   - luacheck ./src
   - busted
+  - TEST_NGINX_RANDOMIZE=1 prove -v -r t

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Release process:
 4. commit and tag the release
 5. upload rock to LuaRocks
 
+### Unreleased
+
+- Performance: reduce amount of timers on init_worker
+
 ### 6.0.0 (05-Apr-2021)
 
 - BREAKING: the round-robin balancing algorithm is now implemented in

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Release process:
 
 ### Unreleased
 
-- Performance: reduce amount of timers on init_worker
+- Performance: reduce amount of timers on init_worker. [PR 130](https://github.com/Kong/lua-resty-dns-client/pull/130)
 
 ### 6.0.0 (05-Apr-2021)
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -822,6 +822,10 @@ local function syncQuery(qname, r_opts, try_list, count)
     try_status(try_list, "in progress (sync)")
   end
 
+  if ngx.get_phase() == "init" or ngx.get_phase() == "init_worker" then
+    return item, nil, try_list
+  end
+
   -- block and wait for the async query to complete
   local ok, err = item.semaphore:wait(poolMaxWait)
   if ok and item.result then

--- a/t/00-sanity.t
+++ b/t/00-sanity.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+
+plan tests => 2;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: load lua-resty-dns-client
+--- config
+    location = /t {
+        access_by_lua_block {
+            local client = require("resty.dns.client")
+            assert(client.init())
+            local host = "localhost"
+            local typ = client.TYPE_A
+            local answers, err = assert(client.resolve(host, { qtype = typ }))
+            ngx.say(answers[1].address)
+        }
+    }
+--- request
+GET /t
+--- response_body
+127.0.0.1
+--- no_error_log

--- a/t/001-init.t
+++ b/t/001-init.t
@@ -1,40 +1,40 @@
-use Test::Nginx::Socket 'no_plan';
+use Test::Nginx::Socket;
 
+plan tests => repeat_each() * (blocks() * 3) + 8;
+
+workers(6);
+
+no_shuffle();
 run_tests();
 
 __DATA__
 
-=== TEST 1: init_worker: phase not supported by `semaphore:wait`
+=== TEST 1: reuse timers for queries of same name, independent on # of workers
 --- http_config eval
 qq {
     init_worker_by_lua_block {
         local client = require("resty.dns.client")
-        assert(client.init())
+        assert(client.init({
+            nameservers = { "8.8.8.8" },
+            hosts = {}, -- empty tables to parse to prevent defaulting to /etc/hosts
+            resolvConf = {}, -- and resolv.conf files
+            order = { "A" },
+        }))
         local host = "httpbin.org"
         local typ = client.TYPE_A
-        local answers, err = client.resolve(host, { qtype = typ })
-        ngx.log(ngx.ERR, "answers: ", answers)
-        ngx.log(ngx.ERR, err)
+        for i = 1, 10 do
+            client.resolve(host, { qtype = typ })
+        end
+
+        local host = "mockbin.org"
+        for i = 1, 10 do
+            client.resolve(host, { qtype = typ })
+        end
+
+        workers = ngx.worker.count()
+        timers = ngx.timer.pending_count()
     }
 }
---- config
-    location = /t {
-        echo ok;
-    }
---- request
-GET /t
---- response_body
-ok
---- error_log
-answers: nil
-error: 101 empty record received
---- no_error_log
-dns lookup pool exceeded retries
-API disabled in the context of init_worker_by_lua
-
-
-
-=== TEST 2: access: phase supported by `semaphore:wait`
 --- config
     location = /t {
         access_by_lua_block {
@@ -43,6 +43,86 @@ API disabled in the context of init_worker_by_lua
             local host = "httpbin.org"
             local typ = client.TYPE_A
             local answers, err = client.resolve(host, { qtype = typ })
+
+            if not answers then
+                ngx.say("failed to resolve: ", err)
+            end
+
+            ngx.say("first address name: ", answers[1].name)
+
+            host = "mockbin.org"
+            answers, err = client.resolve(host, { qtype = typ })
+
+            if not answers then
+                ngx.say("failed to resolve: ", err)
+            end
+
+            ngx.say("second address name: ", answers[1].name)
+
+            ngx.say("workers: ", workers)
+
+            -- should be 2 timers maximum (1 for each hostname)
+            ngx.say("timers: ", timers)
+        }
+    }
+--- request
+GET /t
+--- response_body
+first address name: httpbin.org
+second address name: mockbin.org
+workers: 6
+timers: 2
+--- no_error_log
+[error]
+dns lookup pool exceeded retries
+API disabled in the context of init_worker_by_lua
+
+
+
+=== TEST 2: init_worker: phase not supported by `semaphore:wait`
+--- http_config eval
+qq {
+    init_worker_by_lua_block {
+        local client = require("resty.dns.client")
+        assert(client.init())
+        local host = "httpbin.org"
+        local typ = client.TYPE_A
+        answers, err = client.resolve(host, { qtype = typ })
+    }
+}
+--- config
+    location = /t {
+        access_by_lua_block {
+            ngx.say("answers: ", answers)
+            ngx.say("err: ", err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+answers: nil
+err: dns client error: 101 empty record received
+--- no_error_log
+[error]
+dns lookup pool exceeded retries
+API disabled in the context of init_worker_by_lua
+
+
+
+=== TEST 3: access: phase supported by `semaphore:wait`
+--- config
+    location = /t {
+        access_by_lua_block {
+            local client = require("resty.dns.client")
+            assert(client.init())
+            local host = "httpbin.org"
+            local typ = client.TYPE_A
+            local answers, err = client.resolve(host, { qtype = typ })
+
+            if not answers then
+                ngx.say("failed to resolve: ", err)
+            end
+
             ngx.say("address name: ", answers[1].name)
         }
     }
@@ -50,10 +130,14 @@ API disabled in the context of init_worker_by_lua
 GET /t
 --- response_body
 address name: httpbin.org
+--- no_error_log
+[error]
+dns lookup pool exceeded retries
+API disabled in the context of init_worker_by_lua
 
 
 
-=== TEST 3: init_worker: phase not supported by lua-resty-dns `new` API
+=== TEST 4: init_worker: phase not supported by lua-resty-dns `new` API
 --- http_config eval
 qq {
     init_worker_by_lua_block {

--- a/t/001-init.t
+++ b/t/001-init.t
@@ -1,0 +1,75 @@
+use Test::Nginx::Socket 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: init_worker: phase not supported by `semaphore:wait`
+--- http_config eval
+qq {
+    init_worker_by_lua_block {
+        local client = require("resty.dns.client")
+        assert(client.init())
+        local host = "httpbin.org"
+        local typ = client.TYPE_A
+        local answers, err = client.resolve(host, { qtype = typ })
+        ngx.log(ngx.ERR, "answers: ", answers)
+        ngx.log(ngx.ERR, err)
+    }
+}
+--- config
+    location = /t {
+        echo ok;
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- error_log
+answers: nil
+error: 101 empty record received
+--- no_error_log
+dns lookup pool exceeded retries
+API disabled in the context of init_worker_by_lua
+
+
+
+=== TEST 2: access: phase supported by `semaphore:wait`
+--- config
+    location = /t {
+        access_by_lua_block {
+            local client = require("resty.dns.client")
+            assert(client.init())
+            local host = "httpbin.org"
+            local typ = client.TYPE_A
+            local answers, err = client.resolve(host, { qtype = typ })
+            ngx.say("address name: ", answers[1].name)
+        }
+    }
+--- request
+GET /t
+--- response_body
+address name: httpbin.org
+
+
+
+=== TEST 3: init_worker: phase not supported by lua-resty-dns `new` API
+--- http_config eval
+qq {
+    init_worker_by_lua_block {
+        local resolver = require "resty.dns.resolver"
+        resolver:new({ nameservers = "8.8.8.8" })
+    }
+}
+--- config
+    location = /t {
+        echo ok;
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- error_log
+API disabled in the context of init_worker_by_lua
+in function 'udp'
+in function 'new'

--- a/t/01-phases.t
+++ b/t/01-phases.t
@@ -1,0 +1,66 @@
+use Test::Nginx::Socket;
+
+plan tests => repeat_each() * (blocks() * 5);
+
+workers(6);
+
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: client supports access phase
+--- config
+    location = /t {
+        access_by_lua_block {
+            local client = require("resty.dns.client")
+            assert(client.init())
+            local host = "localhost"
+            local typ = client.TYPE_A
+            local answers, err = client.resolve(host, { qtype = typ })
+
+            if not answers then
+                ngx.say("failed to resolve: ", err)
+            end
+
+            ngx.say("address name: ", answers[1].name)
+        }
+    }
+--- request
+GET /t
+--- response_body
+address name: localhost
+--- no_error_log
+[error]
+dns lookup pool exceeded retries
+API disabled in the context of init_worker_by_lua
+
+
+
+=== TEST 2: client does not support init_worker phase
+--- http_config eval
+qq {
+    init_worker_by_lua_block {
+        local client = require("resty.dns.client")
+        assert(client.init())
+        local host = "konghq.com"
+        local typ = client.TYPE_A
+        answers, err = client.resolve(host, { qtype = typ })
+    }
+}
+--- config
+    location = /t {
+        access_by_lua_block {
+            ngx.say("answers: ", answers)
+            ngx.say("err: ", err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+answers: nil
+err: dns client error: 101 empty record received
+--- no_error_log
+[error]
+dns lookup pool exceeded retries
+API disabled in the context of init_worker_by_lua

--- a/t/02-timer-usage.t
+++ b/t/02-timer-usage.t
@@ -1,6 +1,6 @@
 use Test::Nginx::Socket;
 
-plan tests => repeat_each() * (blocks() * 3) + 8;
+plan tests => repeat_each() * (blocks() * 5);
 
 workers(6);
 
@@ -76,84 +76,3 @@ timers: 2
 [error]
 dns lookup pool exceeded retries
 API disabled in the context of init_worker_by_lua
-
-
-
-=== TEST 2: init_worker: phase not supported by `semaphore:wait`
---- http_config eval
-qq {
-    init_worker_by_lua_block {
-        local client = require("resty.dns.client")
-        assert(client.init())
-        local host = "httpbin.org"
-        local typ = client.TYPE_A
-        answers, err = client.resolve(host, { qtype = typ })
-    }
-}
---- config
-    location = /t {
-        access_by_lua_block {
-            ngx.say("answers: ", answers)
-            ngx.say("err: ", err)
-        }
-    }
---- request
-GET /t
---- response_body
-answers: nil
-err: dns client error: 101 empty record received
---- no_error_log
-[error]
-dns lookup pool exceeded retries
-API disabled in the context of init_worker_by_lua
-
-
-
-=== TEST 3: access: phase supported by `semaphore:wait`
---- config
-    location = /t {
-        access_by_lua_block {
-            local client = require("resty.dns.client")
-            assert(client.init())
-            local host = "httpbin.org"
-            local typ = client.TYPE_A
-            local answers, err = client.resolve(host, { qtype = typ })
-
-            if not answers then
-                ngx.say("failed to resolve: ", err)
-            end
-
-            ngx.say("address name: ", answers[1].name)
-        }
-    }
---- request
-GET /t
---- response_body
-address name: httpbin.org
---- no_error_log
-[error]
-dns lookup pool exceeded retries
-API disabled in the context of init_worker_by_lua
-
-
-
-=== TEST 4: init_worker: phase not supported by lua-resty-dns `new` API
---- http_config eval
-qq {
-    init_worker_by_lua_block {
-        local resolver = require "resty.dns.resolver"
-        resolver:new({ nameservers = "8.8.8.8" })
-    }
-}
---- config
-    location = /t {
-        echo ok;
-    }
---- request
-GET /t
---- response_body
-ok
---- error_log
-API disabled in the context of init_worker_by_lua
-in function 'udp'
-in function 'new'


### PR DESCRIPTION
We end up scheduling 1 timer for each hostname on the init_worker phase. To fix it we are "deduplicating" timers created to resolve the same hostname for the asynchronous case. That is, we are reusing timers for DNS queries of the same hostname. If we have 6k targets, and all of the targets are "httpbin.org" there's no reason to create 6k timers per worker. Instead, we should just create a maximum of 3 timers for 3 DNS queries (default: 1 for SRV, 1 for A and 1 for CNAME) and don't schedule more timers than that to resolve the same hostname. We should only schedule more timers if we try to resolve different hostnames. And the approach we're using in the patch is: if the current nginx phase can't be blocked by a semaphore (which is the case of init_worker context, but not of timer context), then we should not schedule more timers for the same hostname, we should just return the previous query so that the previous timers can be reutilized (in the init_worker phase, for example). Otherwise, if the current nginx phase *can* blocked by a semaphore, then we will just block and wait for the DNS query to complete (in the timer context, for example, and this hasn't changed). In a nutshell: we are reutilizing timers scheduled to resolve the same hostname.