### PR TITLE
fix(client) ensure `validTtl` override does not interfere with TTL of

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ Release process:
 4. commit and tag the release
 5. upload rock to LuaRocks
 
-### 6.0.1 (22-Jun-2021) 
+### 6.0.x (unreleased)
+
+- Fix: `validTtl` should not be used for host-file entries.
+  [PR 134](https://github.com/Kong/lua-resty-dns-client/pull/134)
+
+### 6.0.1 (22-Jun-2021)
 
 - Performance: reduce amount of timers on init_worker. [PR 130](https://github.com/Kong/lua-resty-dns-client/pull/130)
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -460,9 +460,6 @@ _M.init = function(options)
   staleTtl = options.staleTtl or 4
   log(DEBUG, PREFIX, "staleTtl = ", staleTtl)
 
-  validTtl = options.validTtl
-  log(DEBUG, PREFIX, "validTtl = ", tostring(validTtl))
-
   cacheSize = options.cacheSize or 10000  -- default set here to be able to reset the cache
   noSynchronisation = options.noSynchronisation
   log(DEBUG, PREFIX, "noSynchronisation = ", tostring(noSynchronisation))
@@ -543,6 +540,12 @@ _M.init = function(options)
     end
   end
 
+  -- see: https://github.com/Kong/kong/issues/7444
+  -- since the validTtl affects ttl of caching entries,
+  -- only set it after hosts entries are inserted
+  -- so that the 10 years of TTL for hosts file actually takes effect.
+  validTtl = options.validTtl
+  log(DEBUG, PREFIX, "validTtl = ", tostring(validTtl))
 
   -- Deal with the `resolv.conf` file
 


### PR DESCRIPTION
entries from hosts files

See: https://github.com/Kong/kong/issues/7444 for bug report

The `validTtl` setting forcibly overwrites TTL inside the `cacheinsert`
function. However, this inadvertently overrides the TTL of hosts file
entries as well so that they may expire prematurely, causing resolving
failures later.

This PR changes so that `validTtl` will only be enabled after all
entries from hosts file are inserted.