### PR TITLE
fix(client) allow semaphore wait in some ssl_* phases

### DIFF
--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -831,6 +831,8 @@ local function syncQuery(qname, r_opts, try_list, count)
     access = true,
     content = true,
     timer = true,
+    ssl_cert = true,
+    ssl_session_fetch = true,
   }
 
   local ngx_phase = get_phase()


### PR DESCRIPTION
`ssl_cert` and `ssl_session_fetch` can both yield, but were missing from
the supported list. Without this, a client running in one of these
phases may fail to resolve unexpectedly.
