### PR TITLE
fix(balancer) avoid unnecessary indices redistribution

### DIFF
--- a/src/resty/dns/balancer/base.lua
+++ b/src/resty/dns/balancer/base.lua
@@ -158,6 +158,7 @@ local math_floor = math.floor
 local string_format = string.format
 local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
+local ngx_NOTICE = ngx.NOTICE
 local ngx_WARN = ngx.WARN
 local balancer_id_counter = 0
 
@@ -631,6 +632,9 @@ local function update_dns_result(self, newQuery, dns)
 
     -- delete addresses previously disabled
     self:deleteAddresses()
+  else
+    ngx_log(ngx_NOTICE, self.log_prefix, "skipping afterHostUpdate dirty[",
+            dirty, "] healthy[", self.healthy, "] addresses[", #self.addresses, "]")
   end
 
   ngx_log(ngx_DEBUG, self.log_prefix, "querying dns and updating for ", self.hostname, " completed")
@@ -1019,6 +1023,9 @@ function objBalancer:addHost(hostname, port, nodeWeight)
       if dirty and (self.healthy or #self.addresses > 0) then
         -- update had an impact so must redistribute indices
         self:afterHostUpdate(host)
+      else
+        ngx_log(ngx_NOTICE, self.log_prefix, "skipping afterHostUpdate dirty[",
+                dirty, "] healthy[", self.healthy, "] addresses[", #self.addresses, "]")
       end
     end
   end

--- a/src/resty/dns/balancer/base.lua
+++ b/src/resty/dns/balancer/base.lua
@@ -620,7 +620,7 @@ local function update_dns_result(self, newQuery, dns)
   self.lastQuery = newQuery
   self.lastSorted = newSorted
 
-  if dirty then
+  if dirty and (self.healthy or #self.addresses > 0) then
     -- above we already added and updated records. Removed addresses are disabled, and
     -- need yet to be deleted from the Host
     ngx_log(ngx_DEBUG, self.log_prefix, "updating balancer based on dns changes for ",
@@ -1016,7 +1016,7 @@ function objBalancer:addHost(hostname, port, nodeWeight)
     if host.nodeWeight ~= nodeWeight then
       -- weight changed, go update
       local dirty = host:change(nodeWeight)
-      if dirty then
+      if dirty and (self.healthy or #self.addresses > 0) then
         -- update had an impact so must redistribute indices
         self:afterHostUpdate(host)
       end


### PR DESCRIPTION
this change was only tested without health checks and (for now) is
aimed for an environment with a ton of invalid hostnames configured.
it must be better tested before merging.